### PR TITLE
Launch straight into a zone with a minimal viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ browse the FTABLE/VTABLE file-id → DAT mapping:
 
 | Path | Purpose |
 |---|---|
-| `ui/` | Frontend, built by Vite. `ui/js/` is the engine as vanilla ES modules — `dat.js` (DAT section walker + skeleton/mesh/texture/animation parsers), `pose.js` (pose evaluation), `renderer.js` (WebGL2, GPU skinning, DXT via `WEBGL_compressed_texture_s3tc` + CPU fallback), `camera.js`, `backend.js`, audio/particle helpers. `ui/src/` is the React UI (viewport, panels, asset lists). |
+| `ui/` | Frontend, built by Vite. `ui/js/` is the engine as vanilla ES modules — `dat.js` (DAT section walker + skeleton/mesh/texture/animation parsers), `pose.js` (pose evaluation), `renderer.js` (WebGL2, GPU skinning, DXT via `WEBGL_compressed_texture_s3tc` + CPU fallback), `camera.js`, `backend.js`, `launch.js` (CLI / query-string launch options), audio/particle helpers. `ui/src/` is the React UI (viewport, panels, asset lists). |
 | `src-tauri/` | Rust shell. IPC commands for filesystem access (`list_dir`, `read_file`, `write_file`), native pickers, audio decode (`decode_vgmstream`), model export (`xi_mesh_export`), and reveal-in-file-manager (`reveal_path`). |
 | `dev/serve.py` | Dev server: serves `ui/` plus `/fs` endpoints so the frontend runs in a plain browser without Tauri (`backend.js` falls back automatically). |
 | `dev/bake-lists.mjs` | Regenerates the baked asset lists in `ui/public/lists/` (races, gear, NPCs, music, SFX) from source data. |
@@ -129,6 +129,44 @@ python dev/serve.py 8766
 
 then open http://localhost:8766. `window.xi` exposes the renderer for
 debugging.
+
+## Zone preview launch
+
+Another tool — a zone editor's *Preview* button, a shortcut, a shell — can start
+the viewer straight on a zone, with none of the app around it:
+
+```
+xi-model-viewer.exe --zone "ROM/171/34.DAT"
+```
+
+That opens the zone alone: the viewport plus the Zone panel (weather, time of
+day, fog, brightness, scene background, zone BGM and ambient volume). No menu
+bar, no asset panel, no status bars, no object browser. Fly controls (WASD /
+QE / Shift boost, wheel for speed) work as they do in the app, `F` re-frames the
+zone, and the window title becomes the zone name. A preview is a side trip — it doesn't overwrite the session the full app
+restores on its next normal launch.
+
+| Option | Meaning |
+|---|---|
+| `--zone <dat\|id>` | Zone to open: `ROM/171/34.DAT`, a leveleditor `game/ROM/…` path, the DAT's absolute path, or a zone id (`--zone 200`). |
+| `--minimal` | Chrome-free viewer. The default whenever `--zone` is given. |
+| `--full-ui` | Open the same zone in the whole app instead. |
+| `--weather <id>` | Starting weather — `fine`, `rain`, `snow`, `aura`, … Ignored (with a console warning) if the zone doesn't have it. |
+| `--time <t>` | Starting time of day, `HH:MM` or minutes past midnight. |
+| `--clock` | Run the day clock — a full FFXI day per real minute. |
+
+`--zone` is resolved against the configured game path (and the HD path, when HD
+is on), so an absolute DAT path from either install works. If the game path
+hasn't been set yet, the preview window asks for it and then opens the zone.
+
+Browser dev mode takes the same options as a query string, which is the quickest
+way to try one out:
+
+```
+http://localhost:5173/?zone=ROM/171/34.DAT&time=18:00&weather=rain
+```
+
+(`ui=full` is the query-string spelling of `--full-ui`.)
 
 ## Environment variables
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -333,6 +333,21 @@ fn xi_mesh_export(
     }
 }
 
+/// Command-line arguments the app was launched with (argv[0] dropped).
+///
+/// Parsed on the frontend (`ui/js/launch.js`) so one parser covers both the
+/// Tauri shell and browser dev mode, where the same options arrive as a query
+/// string. Used by the zone-preview launch: `xi-model-viewer --zone ROM/171/34.DAT`.
+#[tauri::command]
+fn launch_args() -> Vec<String> {
+    // args_os + lossy: a path the shell handed us in some other encoding is
+    // worth showing mangled, but never worth panicking over.
+    std::env::args_os()
+        .skip(1)
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect()
+}
+
 #[tauri::command]
 fn default_game_path() -> String {
     // XI_GAME_DIR is returned as-is so a mistyped override is visible in the
@@ -512,7 +527,8 @@ fn main() {
             xi_mesh_export,
             xi_available,
             open_url,
-            reveal_path
+            reveal_path,
+            launch_args
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/ui/css/app.css
+++ b/ui/css/app.css
@@ -823,6 +823,19 @@ button.gs-tool:focus-visible {
 }
 .status-path-link:hover { background: none; color: var(--accent); text-decoration: underline; }
 
+/* --- Zone preview launch (--zone … --minimal) ------------------------------ */
+/* The minimal window has no status bar, so a failed launch says so here. */
+#launchError {
+  bottom: 12px; left: 12px; right: 12px;
+  margin: 0 auto;
+  max-width: 640px;
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 14px;
+  color: var(--gray-100);
+  font-size: 13px;
+}
+#launchError > .icon { color: #e07068; font-size: 18px; flex: 0 0 auto; }
+
 /* --- Zone objects panel (top-right, same band as viewbar) ----------------- */
 
 /* --- Zone weather / time-of-day panel (top-right, above Objects) ----------- */
@@ -1125,10 +1138,16 @@ body:has(#placements) #animbar { right: 344px; }
    so every floating panel's header matches. The blue icon beside it stays. */
 .details-title, .plc-title, .wx-title {
   flex: 1 1 auto;
+  min-width: 0;
   color: var(--gray-500);
   font: 600 11px/1.4 var(--font-ui);
   text-transform: uppercase;
   letter-spacing: 0.04em;
+  /* The preview launch puts the zone's own name here, which can outrun the
+     header — keep it on one line rather than pushing the sky toggle out. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .details-close { width: 24px; height: 24px; min-height: 0; background: transparent; border: none; box-shadow: none; }
 .details-close:hover { background: rgba(255, 255, 255, 0.1); }

--- a/ui/js/backend.js
+++ b/ui/js/backend.js
@@ -134,6 +134,21 @@ export const backend = {
     window.open(url, '_blank', 'noopener,noreferrer');
   },
 
+  /**
+   * The command line the app was launched with (argv[0] dropped). Browser dev
+   * mode has no argv — the same options arrive as a query string there, which
+   * js/launch.js reads directly.
+   */
+  async launchArgs() {
+    if (!isTauri()) return [];
+    try {
+      const argv = await tauriInvoke('launch_args');
+      return Array.isArray(argv) ? argv : [];
+    } catch {
+      return [];   // older shell without the command — no launch options
+    }
+  },
+
   /** Shows a file in the system file manager (Explorer/Finder), selected. */
   async revealPath(path) {
     if (isTauri()) return tauriInvoke('reveal_path', { path });

--- a/ui/js/launch.js
+++ b/ui/js/launch.js
@@ -1,0 +1,157 @@
+/**
+ * Launch options — how another app (an editor's "Preview" button, a shortcut,
+ * a shell) asks the viewer to come up already showing a zone.
+ *
+ *   Tauri:    xi-model-viewer.exe --zone "ROM/171/34.DAT" [--time 18:00] [--weather rain]
+ *   Browser:  index.html?zone=ROM/171/34.DAT&time=18:00&weather=rain
+ *
+ * A `--zone` launch is *minimal* by default: no menu bar, no asset panel, no
+ * status bars, no object browser — just the zone and the Zone panel (weather,
+ * time of day, fog, brightness, audio). `--full-ui` opens the same zone in the
+ * whole app instead.
+ *
+ * Options:
+ *   --zone <dat|id>  zone DAT (game-relative `ROM/171/34.DAT`, a leveleditor
+ *                    `game/ROM/…` path, or the DAT's absolute path), or a zone id
+ *   --minimal        chrome-free viewer (the default when --zone is given)
+ *   --full-ui        keep the whole app around the zone
+ *   --weather <id>   starting weather, e.g. fine / rain / snow / aura
+ *   --time <t>       starting time of day, `HH:MM` or minutes past midnight
+ *   --clock          run the day clock (a full FFXI day per minute)
+ *
+ * Both parsers below are pure so the same option set works whichever way the
+ * viewer was started.
+ */
+
+import { backend } from './backend.js';
+
+/** Long names that consume the next argv entry (or an `=value`). */
+const VALUE_FLAGS = new Set(['zone', 'weather', 'time']);
+/** Short forms, for hand-typed launches. */
+const ALIASES = { z: 'zone', w: 'weather', t: 'time', m: 'minimal' };
+
+const NO_LAUNCH = Object.freeze({
+  zone: null, minimal: false, weather: null, timeMinutes: null, clock: false,
+});
+
+/** `--flag`, `--flag=0`, `--flag=false`: absent value means "on". */
+function flagOn(value) {
+  if (value == null) return true;
+  const v = String(value).trim().toLowerCase();
+  return !(v === '0' || v === 'false' || v === 'no' || v === 'off');
+}
+
+/**
+ * `HH:MM` or minutes past midnight → minutes in [0, 1440), or null if the
+ * value is not a time at all.
+ */
+export function parseLaunchTime(value) {
+  if (value == null) return null;
+  const s = String(value).trim();
+  const hhmm = /^(\d{1,2}):(\d{1,2})$/.exec(s);
+  let minutes;
+  if (hhmm) minutes = Number(hhmm[1]) * 60 + Number(hhmm[2]);
+  else if (/^\d+(\.\d+)?$/.test(s)) minutes = Math.round(Number(s));
+  else return null;
+  if (!Number.isFinite(minutes)) return null;
+  return ((minutes % 1440) + 1440) % 1440;
+}
+
+/**
+ * Reduce a `--zone` value to the path loadZone wants: relative to the install
+ * root, Windows-separated. Callers pass the configured roots (HD pack, game
+ * dir) so an absolute DAT path inside either is trimmed back to `ROM\…`.
+ */
+export function launchZoneRel(value, roots = []) {
+  let p = String(value ?? '').trim()
+    .replace(/^["']|["']$/g, '')     // a quoted path pasted into a shortcut
+    .replace(/\//g, '\\');
+  for (const root of roots) {
+    if (!root) continue;
+    const r = String(root).replace(/\//g, '\\').replace(/\\+$/, '');
+    if (p.toLowerCase().startsWith(`${r.toLowerCase()}\\`)) {
+      p = p.slice(r.length);
+      break;
+    }
+  }
+  p = p.replace(/^\\+/, '').replace(/^game\\/i, '');
+  // An absolute path from somewhere we don't know (a copy of the install, a
+  // different drive letter): keep it from the ROM folder on.
+  const rom = /(?:^|\\)((?:ROM|SOUND|VIDEO)\d*\\.*)$/i.exec(p);
+  return rom ? rom[1] : p;
+}
+
+/** Shape the collected key/values into the options the app reads. */
+function normalize(raw) {
+  const zone = raw.zone == null ? '' : String(raw.zone).trim();
+  if (!zone) return { ...NO_LAUNCH };
+  // Minimal unless asked otherwise; an explicit --minimal beats --full-ui.
+  const minimal = raw.minimal != null ? !!raw.minimal : !raw.fullUi;
+  return {
+    zone,
+    minimal,
+    weather: raw.weather ? String(raw.weather).trim().toLowerCase() : null,
+    timeMinutes: parseLaunchTime(raw.time),
+    clock: !!raw.clock,
+  };
+}
+
+/** Parse a Tauri/CLI argv (argv[0] already dropped). */
+export function parseLaunchArgs(argv = []) {
+  const args = (argv ?? []).map((a) => String(a));
+  const raw = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith('-')) continue;    // bare paths (file association) aren't options
+    const eq = arg.indexOf('=');
+    const name = (eq >= 0 ? arg.slice(0, eq) : arg).replace(/^--?/, '').toLowerCase();
+    const key = ALIASES[name] ?? name;
+    let value = eq >= 0 ? arg.slice(eq + 1) : null;
+    if (VALUE_FLAGS.has(key) && value === null) {
+      const next = args[i + 1];
+      // A DAT path never starts with '-', so this can't swallow the next flag.
+      if (next !== undefined && !next.startsWith('-')) {
+        value = next;
+        i++;
+      }
+    }
+    switch (key) {
+      case 'zone': case 'weather': case 'time':
+        if (value !== null) raw[key] = value;
+        break;
+      case 'minimal': raw.minimal = flagOn(value); break;
+      case 'no-minimal': raw.minimal = !flagOn(value); break;
+      case 'full-ui': case 'fullui': raw.fullUi = flagOn(value); break;
+      case 'clock': raw.clock = flagOn(value); break;
+      default: break;                       // unknown flags are the shell's business
+    }
+  }
+  return normalize(raw);
+}
+
+/** Parse the browser-dev-mode equivalent: `?zone=…&time=…`. */
+export function parseLaunchSearch(search = '') {
+  const q = new URLSearchParams(search);
+  if (!q.has('zone')) return { ...NO_LAUNCH };
+  const raw = { zone: q.get('zone'), weather: q.get('weather'), time: q.get('time') };
+  if (q.has('minimal')) raw.minimal = flagOn(q.get('minimal'));
+  // ?ui=full is the query-string spelling of --full-ui.
+  if (q.has('ui')) raw.fullUi = String(q.get('ui')).toLowerCase() === 'full';
+  if (q.has('clock')) raw.clock = flagOn(q.get('clock'));
+  return normalize(raw);
+}
+
+/**
+ * The launch options for this run: CLI args in the Tauri shell, the query
+ * string in a browser (and as an override when the app is started by a URL).
+ * Never throws — a bad launch line just means "open normally".
+ */
+export async function readLaunchOptions() {
+  const fromUrl = parseLaunchSearch(window.location?.search ?? '');
+  if (fromUrl.zone) return fromUrl;
+  try {
+    return parseLaunchArgs(await backend.launchArgs());
+  } catch {
+    return { ...NO_LAUNCH };
+  }
+}

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -73,6 +73,7 @@ import { ImageViewer } from './ImageViewer.jsx';
 import { WeatherPanel } from './WeatherPanel.jsx';
 import { Tooltip } from './Tooltip.jsx';
 import { loadZoneNavmesh } from '../js/navmesh.js';
+import { launchZoneRel } from '../js/launch.js';
 
 const DEFAULT_DAT_SUFFIX = 'ROM\\5\\3.DAT';
 const DEFAULT_BG = '#303438';
@@ -306,7 +307,15 @@ async function buildZoneDatDoc(kind, bytes, relPath, settings, tablesRef) {
   return { ...base, entries, obfuscated, conversations };
 }
 
-export default function App() {
+export default function App({ launch = null }) {
+  // Zone preview launch (`--zone <dat> [--minimal]`, see js/launch.js). Minimal
+  // mode drops the whole app chrome — menu bar, asset panel, status bars,
+  // object browser — leaving the viewport and the Zone panel (weather, time of
+  // day, fog, brightness, audio). The prop never changes for a given run, so
+  // everything below can branch on it freely.
+  const launchRef = useRef(launch);
+  const minimal = !!launch?.zone && !!launch?.minimal;
+
   const canvasRef = useRef(null);
   const rendererRef = useRef(null);
   const modelRef = useRef(null);
@@ -341,6 +350,7 @@ export default function App() {
   // auto-open it again. A missing/false 'booted' flag means this install has
   // never launched before.
   const [helpOpen, setHelpOpen] = useState(() => {
+    if (minimal) return false;    // a preview window is not a first launch
     const firstBoot = localStorage.getItem('booted') !== '1';
     if (firstBoot) {
       try { localStorage.setItem('booted', '1'); } catch { /* quota */ }
@@ -349,6 +359,11 @@ export default function App() {
   });
   const [exportSpec, setExportSpec] = useState(null);
   const [leftView, setLeftViewState] = useState(() => {
+    // A launch zone arrives on the Zones page. Set as the *initial* view, not a
+    // switch: switching runs the view-change cleanup, which would unload the
+    // zone mid-load. Not persisted either — a preview isn't a page the user
+    // navigated to.
+    if (launch?.zone) return 'zones';
     const v = localStorage.getItem(LAST_VIEW_KEY);
     return VIEWS.includes(v) ? v : 'files';
   });
@@ -1741,7 +1756,8 @@ export default function App() {
    * Otherwise restores the last saved camera for this zone, if any.
    */
   const loadZone = useCallback(async (zone, opts = {}) => {
-    const { keepCamera = false, cameraSnap = null } = opts;
+    // `remember: false` keeps a one-off preview out of the session restore.
+    const { keepCamera = false, cameraSnap = null, remember = true } = opts;
     const settings = settingsRef.current;
     if (!settings?.gamePath) {
       setStatusText('Game path not set — open Settings first.');
@@ -1986,12 +2002,14 @@ export default function App() {
       setTexWindows([]);
       releaseOverlay();
       setStatusText('');   // zone stats live in Details
-      try {
-        localStorage.setItem(LAST_DAT_KEY, JSON.stringify({
-          kind: 'zone',
-          zone: { id: zone.id, name: zone.name, path: zone.path },
-        }));
-      } catch { /* quota */ }
+      if (remember) {
+        try {
+          localStorage.setItem(LAST_DAT_KEY, JSON.stringify({
+            kind: 'zone',
+            zone: { id: zone.id, name: zone.name, path: zone.path },
+          }));
+        } catch { /* quota */ }
+      }
       return { ok: true };
     } catch (err) {
       console.error(err);
@@ -2328,6 +2346,64 @@ export default function App() {
     onError: (msg) => setStatusText(msg),
   });
 
+  // --- zone preview launch -------------------------------------------------
+
+  // Why the launch zone couldn't be opened (minimal mode has no status bar to
+  // say it in).
+  const [launchError, setLaunchError] = useState('');
+  // --weather / --time / --clock, applied once the zone's environment is up.
+  const pendingLaunchSceneRef = useRef(null);
+
+  /**
+   * Open the zone named on the launch line: a DAT path (game-relative,
+   * `game/ROM/…`, or absolute) or a zone id. Called on startup, and again after
+   * the game path is filled in — a preview launch on a fresh install should
+   * still land on its zone rather than the demo model.
+   */
+  const openLaunchZone = useCallback(async () => {
+    const opts = launchRef.current;
+    if (!opts?.zone) return false;
+    const raw = String(opts.zone).trim();
+    let zones = [];
+    try { zones = await (await fetch('lists/zones.json')).json(); } catch { /* baked list unavailable */ }
+
+    let zone;
+    if (/^\d+$/.test(raw)) {
+      const hit = zones.find((z) => z.id === Number(raw));
+      if (!hit) {
+        setLaunchError(`No zone with id ${raw}.`);
+        setStatusText(`Zone id ${raw} not found.`);
+        return false;
+      }
+      zone = { id: hit.id, name: hit.name, path: hit.path };
+    } else {
+      const s = settingsRef.current;
+      const rel = launchZoneRel(raw, [s?.hdPath, s?.gamePath]);
+      // Prefer the baked entry: it carries the zone name and the id the BGM
+      // lookup needs. An unlisted DAT (a prototype zone) still opens by path.
+      const hit = zones.find((z) => zoneDatRelPath(z.path).toLowerCase() === rel.toLowerCase());
+      zone = hit
+        ? { id: hit.id, name: hit.name, path: hit.path }
+        : { id: null, name: rel, path: `game/${rel.replace(/\\/g, '/')}` };
+    }
+
+    setLaunchError('');
+    pendingLaunchSceneRef.current = (opts.weather || opts.timeMinutes != null || opts.clock)
+      ? { weather: opts.weather, timeMinutes: opts.timeMinutes, clock: opts.clock }
+      : null;
+    // A preview is a side trip — don't overwrite the session's last-opened DAT.
+    const result = await loadZone(zone, { remember: !opts.minimal });
+    if (result?.ok === false) {
+      pendingLaunchSceneRef.current = null;
+      setLaunchError(`Could not open ${zone.name} — ${result.reason}.`);
+      return false;
+    }
+    // The window is the preview of one zone; name it so in the taskbar.
+    if (opts.minimal) document.title = `${zone.name} — XI Model Viewer`;
+    if (settingsRef.current?.autoWasdZones !== false) setWasd(true);
+    return true;
+  }, [loadZone, setWasd]);
+
   // --- startup -------------------------------------------------------------
 
   useEffect(() => {
@@ -2354,6 +2430,13 @@ export default function App() {
           setSettingsError(`Game path not found:\n${gamePath}`);
           setSettingsOpen(true);
           setStatusText('Game path not found — open Settings to fix it.');
+          return;
+        }
+
+        // Launched as a zone preview — that zone is the whole session; the
+        // last-opened DAT and the restored page have no say in it.
+        if (launchRef.current?.zone) {
+          await openLaunchZone();
           return;
         }
 
@@ -2418,7 +2501,7 @@ export default function App() {
         setStatusText(`Startup failed: ${err.message ?? err}`);
       }
     })();
-  }, [loadModel, loadZone, setWasd]);
+  }, [loadModel, loadZone, setWasd, openLaunchZone]);
 
   // Debug/verification hook (used by the headless capture flow)
   useEffect(() => {
@@ -3728,6 +3811,12 @@ export default function App() {
     if (gamePath.toLowerCase() !== prevPath.toLowerCase() || !modelRef.current) {
       keyTablesRef.current = null;   // FFXiMain.dll keys are install-specific
       globalEffectsRef.current = null;
+      // Preview launch that had nowhere to read from until now: open the zone
+      // it was started for, not the demo model.
+      if (launchRef.current?.zone) {
+        await openLaunchZone();
+        return;
+      }
       const dat = `${gamePath}\\${DEFAULT_DAT_SUFFIX}`;
       await loadModel([dat], DEFAULT_DAT_SUFFIX);
       setRevealTarget(dat.toLowerCase());
@@ -4077,6 +4166,24 @@ export default function App() {
     return () => cancelAnimationFrame(raf);
   }, [todPlaying, applyWeatherTime]);
 
+  /**
+   * Apply `--weather` / `--time` / `--clock` from the launch line. Deferred to
+   * here because the weather has to exist in the zone before it can be
+   * switched to, and that list only arrives when the zone has finished loading.
+   */
+  useEffect(() => {
+    const pending = pendingLaunchSceneRef.current;
+    if (!pending || !zoneEnvManagerRef.current) return;
+    pendingLaunchSceneRef.current = null;
+    let w = weather;
+    if (pending.weather) {
+      if (weatherList.includes(pending.weather)) w = pending.weather;
+      else console.warn(`launch: this zone has no '${pending.weather}' weather — keeping ${weather || 'its default'}`);
+    }
+    applyWeatherTime(w, pending.timeMinutes ?? timeMinutes);
+    if (pending.clock) setTodPlaying(true);
+  }, [weatherList, weather, timeMinutes, applyWeatherTime]);
+
   // Leaving the Zones view takes its panel — and the stop button — off screen,
   // so don't leave the clock running where it can't be stopped.
   useEffect(() => {
@@ -4309,30 +4416,102 @@ export default function App() {
 
   // --- render --------------------------------------------------------------
 
+  // The viewport, hoisted so the minimal tree below mounts the same element
+  // (and therefore the same GL context) as the full one.
+  const viewport = (
+    <canvas
+      id="canvas"
+      ref={canvasRef}
+      className={liveSelection && (leftView === 'zones' || browserKind === 'zone') ? 'live-pick' : undefined}
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+      onPointerMove={onPointerMove}
+      onPointerLeave={() => {
+        if (gizmoHoverRef.current) {
+          gizmoHoverRef.current = null;
+          rendererRef.current?.setGizmoHoverAxis?.(null);
+        }
+        if (plcHoverRef.current) {
+          plcHoverRef.current = null;
+          syncZonePickHighlight();
+        }
+        if (canvasRef.current) {
+          canvasRef.current.style.cursor = liveSelectionRef.current ? 'crosshair' : '';
+        }
+      }}
+      onContextMenu={(e) => e.preventDefault()}
+    />
+  );
+
+  const zonePanel = (
+    <WeatherPanel
+      weathers={weatherList}
+      weather={weather}
+      timeMinutes={timeMinutes}
+      onChange={applyWeatherTime}
+      todPlaying={todPlaying}
+      onToggleTod={setTodPlaying}
+      skyboxOn={showSkybox}
+      onToggleSkybox={setSkybox}
+      hasSkybox={hasSkybox}
+      heading={minimal ? (modelInfo?.name || 'Zone') : 'Zone'}
+      objectsOpen={!minimal && !!objectGroups && plcOpen}
+      bgColor={settings?.bgColor ?? DEFAULT_BG}
+      onBg={setBg}
+      brightness={zoneBrightness}
+      onBrightness={setZoneBrightness}
+      fogOn={fogOn}
+      onFogOn={setFogOn}
+      fogScale={fogScale}
+      onFogScale={setFogScale}
+      musicVolume={player.volume}
+      onMusicVolume={player.setVolume}
+      sfxVolume={sfxVolume}
+      onSfxVolume={setSfxVolume}
+      sfxOn={sfxOn}
+      onToggleSfx={toggleSfx}
+      zoneTrack={zoneTrack}
+      zoneTrackPlaying={
+        !!zoneTrack && player.playing
+        && player.current?.file === zoneTrack.file && player.current?.root === zoneTrack.root
+      }
+      onToggleZoneMusic={toggleZoneMusic}
+    />
+  );
+
+  // Zone preview (`--zone … --minimal`): the viewport and the Zone panel, and
+  // nothing else. Settings still mount — a preview launched before the game
+  // path was ever set needs somewhere to set it.
+  if (minimal) {
+    return (
+      <>
+        {viewport}
+        {modelInfo?.zone && zonePanel}
+        {launchError && (
+          <div id="launchError" className="panel" role="alert">
+            <span className="icon">error</span>
+            <span>{launchError}</span>
+          </div>
+        )}
+        <SettingsModal
+          open={settingsOpen}
+          initial={settings ?? { gamePath: '', hdPath: '', hdEnabled: false, bgColor: DEFAULT_BG, autoPlay: false, autoWasdZones: true, xiPath: '' }}
+          error={settingsError}
+          onSave={saveSettings}
+          onClose={() => { setSettingsOpen(false); setSettingsError(''); }}
+        />
+        <LoadingOverlay
+          open={!!loading}
+          title={loading?.title}
+          detail={loading?.detail}
+        />
+      </>
+    );
+  }
+
   return (
     <>
-      <canvas
-        id="canvas"
-        ref={canvasRef}
-        className={liveSelection && (leftView === 'zones' || browserKind === 'zone') ? 'live-pick' : undefined}
-        onPointerDown={onPointerDown}
-        onPointerUp={onPointerUp}
-        onPointerMove={onPointerMove}
-        onPointerLeave={() => {
-          if (gizmoHoverRef.current) {
-            gizmoHoverRef.current = null;
-            rendererRef.current?.setGizmoHoverAxis?.(null);
-          }
-          if (plcHoverRef.current) {
-            plcHoverRef.current = null;
-            syncZonePickHighlight();
-          }
-          if (canvasRef.current) {
-            canvasRef.current.style.cursor = liveSelectionRef.current ? 'crosshair' : '';
-          }
-        }}
-        onContextMenu={(e) => e.preventDefault()}
-      />
+      {viewport}
 
       <MenuBar
         onAction={handleMenuAction}
@@ -4553,40 +4732,7 @@ export default function App() {
 
       {/* Stays visible while zone music plays — the play button lives in here,
           so taking the panel over would pull the controls out from under it. */}
-      {!dataStructOpen && (leftView === 'zones' || browserKind === 'zone') && (
-        <WeatherPanel
-          weathers={weatherList}
-          weather={weather}
-          timeMinutes={timeMinutes}
-          onChange={applyWeatherTime}
-          todPlaying={todPlaying}
-          onToggleTod={setTodPlaying}
-          skyboxOn={showSkybox}
-          onToggleSkybox={setSkybox}
-          hasSkybox={hasSkybox}
-          objectsOpen={!!objectGroups && plcOpen}
-          bgColor={settings?.bgColor ?? DEFAULT_BG}
-          onBg={setBg}
-          brightness={zoneBrightness}
-          onBrightness={setZoneBrightness}
-          fogOn={fogOn}
-          onFogOn={setFogOn}
-          fogScale={fogScale}
-          onFogScale={setFogScale}
-          musicVolume={player.volume}
-          onMusicVolume={player.setVolume}
-          sfxVolume={sfxVolume}
-          onSfxVolume={setSfxVolume}
-          sfxOn={sfxOn}
-          onToggleSfx={toggleSfx}
-          zoneTrack={zoneTrack}
-          zoneTrackPlaying={
-            !!zoneTrack && player.playing
-            && player.current?.file === zoneTrack.file && player.current?.root === zoneTrack.root
-          }
-          onToggleZoneMusic={toggleZoneMusic}
-        />
-      )}
+      {!dataStructOpen && (leftView === 'zones' || browserKind === 'zone') && zonePanel}
 
       {!dataStructOpen && objectGroups && plcOpen
         && (leftView === 'zones' || browserKind === 'zone') && (

--- a/ui/src/WeatherPanel.jsx
+++ b/ui/src/WeatherPanel.jsx
@@ -21,9 +21,11 @@ const fmtTime = (min) => {
 /**
  * Zone scene controls (top-right): weather/time when the zone has a skybox,
  * plus always-on background colour and lighting brightness (default → unlit).
+ * `heading` names the panel — "Zone" in the app, the zone's own name when this
+ * is the only panel on screen (the --minimal preview launch).
  */
 export function WeatherPanel({
-  weathers = [], weather, timeMinutes, onChange,
+  weathers = [], weather, timeMinutes, onChange, heading = 'Zone',
   todPlaying = false, onToggleTod,
   skyboxOn, onToggleSkybox, hasSkybox = false, objectsOpen,
   bgColor, onBg,
@@ -89,7 +91,7 @@ export function WeatherPanel({
     <div id="weather" ref={rootRef} className={`panel${objectsOpen ? ' with-objects' : ''}`}>
       <div className="wx-header">
         <span className="icon">landscape</span>
-        <span className="wx-title">Zone</span>
+        <span className="wx-title">{heading}</span>
         {showSkyControls && <span className="wx-time mono">{fmtTime(timeMinutes)}</span>}
         {showSkyControls && (
           <Tooltip content="Show sky" placement="bottom">

--- a/ui/src/main.jsx
+++ b/ui/src/main.jsx
@@ -3,5 +3,12 @@ import { createRoot } from 'react-dom/client';
 import '../css/theme.css';
 import '../css/app.css';
 import App from './App.jsx';
+import { readLaunchOptions } from '../js/launch.js';
 
-createRoot(document.getElementById('root')).render(<App />);
+// Launch options are resolved before the first render so a `--zone … --minimal`
+// preview never flashes the full UI on the way to the chrome-free viewer.
+readLaunchOptions()
+  .catch(() => null)   // a launch line we can't read is not a reason for a blank window
+  .then((launch) => {
+    createRoot(document.getElementById('root')).render(<App launch={launch} />);
+  });


### PR DESCRIPTION
Lets another tool — a zone editor's **Preview** button, a shortcut, a shell — start the viewer already showing a zone, with none of the app around it:

```
xi-model-viewer.exe --zone "ROM/171/34.DAT"
```

That opens the zone alone: the viewport plus the **Zone** panel (weather, time of day, fog, brightness, scene background, zone BGM and ambient volume). No menu bar, no asset panel, no status bars, no object browser. Fly controls (WASD / QE / Shift, wheel for speed) work as they do in the app, `F` re-frames the zone, and the window title becomes the zone name.

## Options

| Option | Meaning |
|---|---|
| `--zone <dat\|id>` | Zone to open: `ROM/171/34.DAT`, a leveleditor `game/ROM/…` path, the DAT's absolute path, or a zone id (`--zone 200`). |
| `--minimal` | Chrome-free viewer. The default whenever `--zone` is given. |
| `--full-ui` | Open the same zone in the whole app instead. |
| `--weather <id>` | Starting weather — `fine`, `rain`, `snow`, `aura`, … Ignored (with a console warning) if the zone doesn't have it. |
| `--time <t>` | Starting time of day, `HH:MM` or minutes past midnight. |
| `--clock` | Run the day clock — a full FFXI day per real minute. |

Browser dev mode takes the same options as a query string, which is the quickest way to try one:

```
http://localhost:5173/?zone=ROM/171/34.DAT&time=18:00&weather=rain
```

## How it works

- **`src-tauri`** — a `launch_args` command hands the process argv to the frontend, so one parser (`ui/js/launch.js`) covers both the Tauri shell and browser dev mode, where the same options arrive as a query string. Options are resolved in `main.jsx` *before* the first render, so a preview never flashes the full UI on the way to the minimal one.
- **Path resolution** — `--zone` is trimmed back against the configured game path (and the HD path when HD is on), so an absolute DAT path from either install works; the value is then matched against the baked zone list so the zone's name and BGM id still come out right. An unlisted prototype DAT opens by path.
- **Minimal render tree** — `App` returns a second, much smaller tree when minimal: viewport, Zone panel, Settings, the loading overlay. Both trees mount the same `<canvas>` element and the same `<WeatherPanel>`, so there's one definition of each.
- **The Zones page is the initial view, not a switch** — switching would run the view-change cleanup and unload the zone mid-load.
- **A preview is a side trip** — it doesn't overwrite the last-opened DAT or the restored page the full app comes back to on its next normal launch, and it doesn't consume the first-launch About greeting.
- **No game path yet** — the preview window asks for one, then opens its zone rather than the demo model.
- A zone that can't be opened says so in a banner (minimal mode has no status bar to say it in).

## Testing

- `npm run build` clean.
- Parser unit checks over every option form: `--zone x` / `--zone=x` / `-z x`, `--full-ui` vs `--minimal` precedence, `--no-minimal`, `--minimal=0`, `HH:MM` and minute times, the four `--zone` path shapes (game-relative, `game/…`, absolute under the game root, absolute under the HD root, quoted), a flag never swallowing the next flag as its value, and the query-string spellings.
- Headless Chromium against the built bundle: `?zone=…` renders canvas + nothing else (no `#menubar`, `#status`, `#statusFile`, no side panel), while a normal launch renders the full chrome; Settings is still reachable in minimal mode when the game path is bad; a zone that fails to parse surfaces the banner and writes nothing to `localStorage`.
- The Rust shell couldn't be compiled here (no GTK/webkit dev libraries in this container) — the change is the one small `launch_args` command plus its handler registration.

Not exercised: a successful zone load end-to-end, which needs a real FFXI install.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTzp2o9cxuiPtDbKgybMnc)_