### PR TITLE
docs: complete CHANGELOG through v1.1.0, and refresh README features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ All notable changes to XI Model Viewer.
 
 Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 
-Version numbers follow the tags that were actually published — 1.0.6, 1.0.7 and
-1.0.11 were never released, so they have no entry here.
+1.0.6, 1.0.7 and 1.0.11 were never released, so they have no entry here.
 
 ---
 
@@ -13,143 +12,48 @@ Version numbers follow the tags that were actually published — 1.0.6, 1.0.7 an
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.12...v1.1.0)
 
-### One Motion picker instead of three
-- **Anim, Schedule and Skill are now a single Motion dropdown**, grouped into
-  Animations / Schedules / Specials, so it is always obvious which one is
-  playing. Ids carry an internal prefix because a schedule and a clip can share
-  a name; a Special stays the shown selection while its own clip runs, rather
-  than flipping over to the entry it added under Animations
-- **NPC panel rows reordered** to Show, Motion, Effect, Playback, Frame, Speed,
-  Volume, Base
-- **Fixed: a Special left its routine armed.** After playing a skill pack,
-  picking a plain animation kept the pack's routine live, so Play re-fired its
-  VFX and sound over an unrelated clip. The routine is now armed only while the
-  pack's own clip is selected, and switching away takes it off the stage too
+### Animation
+- Anim, Schedule and Skill are now a single **Motion** dropdown, grouped into
+  Animations, Schedules and Specials, so it's clear what's playing
+- New **Base** setting (None / Idle / Battle) plays your clip on top of a
+  resting pose, blending in and out of it — so a loop reads as "rest, do the
+  thing, rest". Off by default
+- Fixed: after playing a skill pack, picking a normal animation replayed the
+  pack's effects and sound over it
+- NPC panel rows reordered to a more sensible order
 
-### Base Anim — play an action over a resting pose
-- **Base (None / Idle / Battle)** plays a resting clip underneath and lays your
-  selection over it as a montage: blend in, play through, blend back, rest
-  again. A loop reads as "rest, do the thing, rest" rather than a clip cutting
-  to itself
-- Built on the existing schedule machinery rather than a second system — a
-  schedule clip is already "segments over a base clip blending back out", so the
-  only missing piece was `transIn` in `pose.js`, the mirror of the existing
-  `transOut`. Measured on `at0` over `idl` with 6-frame blends, the pose is exact
-  on the base at both ends
-- A schedule keeps its own command sequencing; only the command that finishes
-  last hands back to the base, so a routine reads as one action instead of
-  sagging between commands
-- **None is the default**, so existing behaviour is unchanged unless you ask for
-  a base
-
-### The floor stays put, and so does the camera
-Two long-standing complaints, both mis-attributed to the camera at first —
-per-frame traces showed `camera.eye` byte-identical across every gesture, so the
-search moved elsewhere.
-
-- **The floor is fixed at Y = 0.** It used to be placed at the model's feet and
-  re-placed whenever the pose changed; frame-0 sole height varies by up to 0.14
-  between clips on one model (`bf0` −0.135 vs `idl` 0.009), so it jumped on
-  every pick and could rise past a low camera — which reads as the camera
-  dropping through the floor. A floor is scenery now, and nothing moves it
-- **Selecting another actor no longer re-frames the camera**, throwing away the
-  shot you just composed. Settings → **Reframe camera on Actor Selection**, off
-  by default. The first actor of a session is still framed, since there is no
-  view to preserve then
-- **Off a zone, the wheel zooms on the orbit centre** rather than the cursor. A
-  zone is a place you navigate; everything else is one subject already centred,
-  and cursor-anchored zoom drags it off centre
+### Camera and floor
+- The floor no longer moves with the model. It used to shift with every
+  animation, which looked like the camera was dropping through it
+- Selecting another actor no longer throws away your camera angle. Turn it back
+  on with Settings → Reframe camera on Actor Selection
+- Outside of zones, the mouse wheel now zooms towards the centre instead of your
+  cursor, so the model doesn't drift off-screen
 
 ### Camera Sequencer
-- **Lock to Actor now aims at bone0002 (the pelvis)** — the actor's centre of
-  mass — so a leap or a step stays framed. The rest-pose bounds centre would let
-  them walk out of shot; it stays as the fallback for anything without a
-  skeleton, such as a bare effect
-- **Scrubbing and stopping hand the camera back in the mode you drive in** —
-  fly with WASD on, orbit otherwise. Only playback needs fly mode, and being
-  stranded in it meant the next drag behaved as the sequence left it rather than
-  as you set it
+- **Lock to Actor** now tracks the actor's hips, so jumps and steps stay in shot
+- Scrubbing and stopping hand the camera back in whatever mode you were using,
+  instead of leaving you in fly mode
 
-### Scene, settings and dropdowns
-- **Settings → Day Length** — real seconds per in-game day for the day/night
-  cycle, default 60. Junk input saves as the default rather than blocking. The
-  button's tooltip is now "Auto Play Day/Night cycle"
-- **Weather and time controls no longer require a 0x2F sky dome** — any zone
-  that declares weather gets them
-- **Navmesh loads from Settings → Navmesh Folder** before falling back to the
-  bundled copy
-- **Combo dropdowns cap at 340px again.** Headless UI's anchor writes an inline
-  `max-height` of the whole viewport, the same override the `max-width` rule
-  already worked around. Group headers are no longer sticky either — pinned at
-  the top, one blocked the panel's highlight gradient and drew as a flat band,
-  so the same header read as two different styles
-- **Details panel texture list restyled** as rows
-- **New background images** — Clouds and Rhapsody, plus the `Basic*` renames.
-  Picked up by the glob in `bgs.js`, so adding one needs no code change
-- Field of view moved above the divider in the Graphics popover
+### Scene and settings
+- Settings → **Day Length** — how many real seconds an in-game day takes
+  (default 60)
+- Weather and time controls now appear for any zone that has weather
+- Navmesh can be loaded from your own folder (Settings → Navmesh Folder)
+- Two new backgrounds: Clouds and Rhapsody
+- Dropdowns no longer stretch the full height of the window
+- Details panel texture list restyled
+- Field of view moved to the top of the Graphics popover
 
-### Code review pass — paths, platforms, races and cleanup
-**No machine-specific paths left in the tree:**
-- Dropped the hardcoded `D:\xidata` AltanaListener vgmstream fallback. vgmstream
-  is already embedded via `include_bytes!` and extracted to the user cache, so
-  the chain is env → co-located → embedded → PATH → None
-- The `xi` CLI shim resolves from `USERPROFILE`/`HOME` instead of a literal
-  `C:\Users\Josh\.local\bin\xi.exe`, matching `find_xi` on the Rust side
-- `bake-*.mjs` now require `--src` rather than defaulting to a personal path
-
-**Correctness:**
-- **`open_url` was Windows-only** despite shipping macOS and Linux bundles; it
-  now has the same `#[cfg]` branches `reveal_path` already had
-- **A zero-length clip froze the model.** `animFrame %= 0` is NaN, which then
-  fed `evaluate()` every frame. `setAnimation` and `seekTo` already guarded
-  against it; the render loop did not
-- **Concurrent sound decodes clobbered each other.** `decode_vgmstream` named its
-  temp file per process, not per call — and Tauri runs sync commands on a thread
-  pool, so a zone load decoding several sounds at once collided. Same fix in
-  `serve.py`
-- **Bumping `VGM_VERSION` now forces a re-extract.** The per-file skip was keyed
-  on byte length alone, so a same-size replacement was never rewritten
-- **Settings save is one `try` block.** Seventeen bare `setItem` calls meant a
-  quota error could persist `gamePath` but not `xiPath`, tearing settings in half
-- **`XI_DATA_DIR` meant two different things** — `main.rs` appended
-  `XiModelViewer`, `tools.rs` used it bare, so setting it split `notes.json` from
-  the xi-tools install. `tools.rs` now matches `main.rs`
-
-**Renderer:**
-- **Added `Renderer.dispose()`.** Nothing freed the GL objects on teardown, so
-  every HMR cycle leaked buffers, VAOs, textures and FBOs. It deliberately does
-  not call `loseContext()`: the canvas outlives the renderer and a lost context
-  stays lost, which would break the next mount
-- **Cached the normalised source path per batch.** `_sourceIn` ran
-  `toLowerCase` + `replace` + a regex for every batch in every draw pass whenever
-  a filter was set
-- **Collapsed `setMeshSourceFilter` and `setHiddenSources`**, which were
-  identical, so filter keys and batch keys cannot drift apart
-
-**Dedup and dead code:**
-- One `github.rs` for the release-fetch algorithm that had three copies, two of
-  them in this crate under different constant names — with offline tests
-- Extracted the diverged `:ensure_rc` from `Start.bat`/`Build.bat` into
-  `scripts/ensure_rc.bat`
-- Deleted `buildSolidGizmoMesh`, `projectRayOnAxis`, `unclaimedTextures`, a stray
-  `console.log` and a dead double-allocation in the skeleton overlay
-
-**`dev/` removed, dev server tightened:**
-- `xi mv update` in xi-tools replaces every baker, so the bake scripts and their
-  JSON are gone. `serve.py` moves to `scripts/` (it is the browser `/fs` backend,
-  which `xi mv update` does not replace), and browser-dev user data moves to
-  `.user-data` at the repo root
-- `_resolve` had a sandbox check whose branches both returned the same value,
-  reading as a guarantee it never gave. Removed, with a docstring saying the
-  `127.0.0.1` bind is the only bound
-- `/fs/list` and `/fs/read` now 404 rather than 500 on a missing file
-- Default dev-server port is 8766, matching what `vite.config.js` proxies to
-
-**Also:** granted `core:event:allow-listen` so the xi-log and tools-progress
-listeners work; the boot update check is skipped on dev builds, which always
-report the committed 1.0.1 and so nagged on every run; dropped the inert
-`PlacementPanel` memo deps and their `void` statements; documented `XI_DATA_DIR`
-and `XI_TOOLS_DIR`.
+### Fixes and cleanup
+- Links now open properly on macOS and Linux, not just Windows
+- Fixed a freeze when an animation had no frames
+- Fixed sounds cutting each other off when a zone loaded several at once
+- Settings no longer save half-way if browser storage is full
+- Fixed a memory leak in the renderer, and sped up drawing when a filter is on
+- Removed leftover hardcoded personal paths from the project
+- Development builds no longer nag about updates on every launch
+- Plenty of dead code removed and duplicated logic merged
 
 ---
 
@@ -157,107 +61,49 @@ and `XI_TOOLS_DIR`.
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.10...v1.0.12)
 
-### NPC effects
-- **Assets → NPCs gets the Both / Mesh / VFX control and the effect volume
-  slider.** An NPC keeps its routines inside the model DAT itself, so the actor's
-  own path is the effect source
-- **Nothing plays until you pick a routine.** An NPC has no `main`: its routines
-  are event-keyed (`dead`, `atk0`, `gurd`, `cast`, `damg`, …) and the server
-  fires them, with nothing in the DAT linking `ded0` to `dead`. The old "main,
-  else first playable" fallback picked an arbitrary routine and replayed it on
-  every clip — one effect for every animation, on every NPC. Routines are now
-  listed in an **Effect** dropdown instead
+### NPCs
+- NPCs can now play their **own visual effects**, with the Both / Mesh / VFX
+  control and an effect volume slider
+- Pick which effect plays from a new **Effect** dropdown. Previously a random
+  one fired on every animation
+- New **Skill** dropdown loads the animation packs a trust borrows, so you can
+  play their special moves
+- Fixed NPC textures being repainted when their effects loaded
+- Fixed models hovering slightly above the floor
 
-### Skill packs
-- **`npcs.json` entries carry `anims: [{path, clips}]`** — the animation packs a
-  trust borrows. Each pack is self-contained: one clip plus its whole VFX bundle
-  under a `main` routine, the same shape as a PC action DAT
-- **A new Skill dropdown loads one pack at a time**, selects its clip and arms
-  its routine. One at a time because a set reuses clip ids, and merging would
-  shadow the duplicates
-
-Two fixes fell out of getting that on screen:
-- **`attachEffectSystem` deleted the incumbent GL texture on a name clash.**
-  Harmless for a PC (separate effect DAT, no overlap), fatal for an NPC whose
-  effect DAT *is* the model DAT — every body texture collided with itself and was
-  re-decoded through the particle path, repainting the model. It now leaves alone
-  the names the geometry actually draws with
-- **The floor was grounded on the bind pose**, whose straight legs hang below
-  every animated one — measured 0.0704 under Iroha's idle soles, which reads as
-  hovering. It re-grounds on frame 0 of each clip, and `fitCamera` no longer
-  undoes that. Framing still uses rest bounds; a pivot that moves with the
-  animation makes the model swim
+### Animation
+- PC battle and weapon-skill animations now load their full-body packs, so
+  they animate properly instead of only partly
+- Bows and other ranged weapons now stay stowed unless the animation actually
+  uses them, instead of hanging in view through every sword swing
+- Fixed a one-frame jolt in the middle of weapon skills like Eagle Eye Shot
 
 ### Camera Sequencer
-- **Lock to Actor** — keyframes record facing the actor, and playback re-solves
-  the rotation every frame rather than interpolating it. Interpolated yaw/pitch
-  cut the corner where the path swings around
-- **Play always runs from the top**, cutting and rewinding the actor clip the way
-  Stop does. It used to resume from the playhead while the actor restarted at 0,
-  so a take begun anywhere but the start ran short against a full-length action
-- **Effects and sound now play.** The paired routine is re-triggered from the
-  clip's loop point, and a sequence runs the clip once with looping off — a shot
-  used to play mesh-only
-- **Scrubbing hands back an orbit camera** at the same eye and look direction.
-  Only playback needs fly mode; leaving it on meant the next drag flew away from
-  the shot
-- **Reaching the end rewinds to frame 0**, so the viewport and the timeline agree
-  on where the next take begins
-- **The working document survives closing the panel** — keyframes, length, fps
-  and toggles. Named sequences stay a separate explicit save
-- **Play at the end of a non-looping clip rewinds first.** It used to advance
-  straight past the end and stop on the same frame, which read as a dead button
+- **Lock to Actor** — keyframes record facing the actor, and playback keeps them
+  in frame
+- Effects and sound now play back with your shot, instead of it being silent
+- Play always starts from the top, and rewinds the actor with it
+- Reaching the end rewinds to the start
+- Pressing Play at the end of a clip now rewinds instead of doing nothing
+- Scrubbing gives you a normal orbit camera back
+- Your work survives closing the panel — named sequences are still saved
+  separately
 
-### Animation fixes
-- **PC battle and weapon-skill packs load properly** — battle skirt (`btl2`)
-  packs load per weapon type, cross-directory `Motion.csv` ranges expand so WS
-  clips get their waist/upper motion DATs, partial clips underlay idle, and
-  stance anims stay visible
-- **No invented blend-out when a schedule segment sets `transOut` 0.** Eagle Eye
-  Shot jittered on the `yu0` → `yu1` hand-off, reading as a single frame of
-  battle stance mid-weapon-skill: the routine leaves a real gap (yu0 ends at 58,
-  yu1 starts at 60) and both carry `transOut` 0, so the substituted 8-frame
-  default had the pose a quarter of the way back to base before the successor
-  claimed the joints. `transOut` 0 means "hand straight over", so the final pose
-  is held instead. Measured across all 21 PC schedules, only `main` changes — its
-  worst per-frame jump drops from 7.965 to 4.974
-- **The ranged weapon is stowed unless the action uses it.** A bow hung in view
-  through every melee swing: ranged weapons have no grip joint to re-parent
-  (`standardJointIndex` 255), so the mesh sat wherever its back-mount bone put
-  it. The game scales the weapon to 0 until it is drawn; the viewer now has a
-  renderer deny-list that does the same, and re-parents the bow onto the bow hand
-  (`gear_sets.json` `handRef`) for actions that use it
+### Scene
+- Scene → **Flat Floor** — a plain coloured ground plane with a colour picker,
+  kept separate from a loaded floor so switching loses nothing
 
-### Scene → Flat Floor
-- **A plain untextured ground plane with a colour picker**, held separately from
-  a loaded floor so ticking it discards nothing. It reuses the existing plane
-  with a 1×1 solid texture, keeping the fade ring, the fog and the model's shadow
-
-### DAT Browser, gear lists and viewers
-- **Fixed a wedged file-index search.** DAT Browser search could stick on
-  "Building file index…" forever. Three things lined up: `loadMergedTables`
-  cached an all-empty result (its per-ROM catch is for uninstalled expansions,
-  but it also swallowed "no game path yet"), `ensureFilePathIndex` guarded with
-  `if (fileIndexRef.current)` and an empty array is truthy, and `FileTree`
-  rendered an empty index and a missing one identically. The Files view is the
-  default on a fresh profile, so the index effect ran before settings landed and
-  poisoned both caches. Now an empty table read throws instead of caching, the
-  guard tests `?.length` and clears the ref on failure, and a failed index says so
-- **Gear sections come from `characters.json` `gearSections`** rather than a
-  hard-coded array, so a new set in the generator needs no change here. Adds
-  Abjuration and the Mythic/Aeonic/Prime weapon sets, and merges Ebur, Furia and
-  Ebon into one section
-- **Weapon-slot leftovers fold into one "Other" bucket** pinned to the bottom —
-  Unidentified, the missing-DAT one-off and everything ungrouped. "None" is
-  exempt and still pins to the top
-- **DAT Browser badges images by group** — UI, Cutscene, Map — instead of calling
-  every image a Map
-- **Data Struct: SkeletonAnimation and Info rows are inspectable**
-- **Texture and image viewers get a persisted background colour** (right-click
-  clears back to the checker) plus zoom and pan
-- **Ctrl+LMB pans** the viewport
-- Gear lists resynced from xi-tools (the Limbus set was retired upstream)
-- AGENTS.md documents how to run the app outside Tauri and debug it
+### Browsing and viewers
+- Fixed DAT Browser search getting stuck on "Building file index…" forever
+- Gear sets now come from the list data, so new sets appear without an update.
+  Adds Abjuration and the Mythic, Aeonic and Prime weapons, and merges Ebur,
+  Furia and Ebon into one section
+- Odds and ends in the weapon lists now group under a single "Other" heading
+- Images are labelled UI, Cutscene or Map rather than everything being "Map"
+- Texture and image viewers remember your background colour and support zoom
+  and pan
+- Skeleton animation and info rows can be inspected in Data Struct
+- Ctrl + left mouse now pans
 
 ---
 
@@ -265,59 +111,38 @@ Two fixes fell out of getting that on screen:
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.9...v1.0.10)
 
-### Zone geometry and culling
-- **PVS region culling** — parses 0x1C `drawDist` / `subAreaId` / `regionPtr` and
-  builds region sets with a camera-based region pick, under **View → Region
-  Culling**
-- **Collision proxies (drawDist 1.0) are hidden**, as are far-copy `m_`/`lnd_`
-  stand-ins when a richer twin is placed — this is the Ru'Aun z-fighting fix.
-  Sub-area sets draw under PVS
-- **Live Selection can pick sub-area, unplaced and collision objects** when they
-  are visible
-- **Section-fourcc mesh aliases are deferred** so they cannot steal real names —
-  this fixes Dynamis `saku` and `stardust`→`star`, plus roughly 69 similar zones
-- The ZoneDef modal shows the sub-area id
+### Zones
+- **Region culling** (View → Region Culling) draws only what the zone says is
+  visible from where you're standing
+- Invisible collision blocks and duplicate distant copies are now hidden, fixing
+  the flickering surfaces in Ru'Aun Gardens
+- Fixed the wrong mesh being drawn in Dynamis and roughly 69 other zones
+- Live Selection can now pick sub-area, unplaced and collision objects
+- The ZoneDef list shows which sub-area an object belongs to
 
 ### Objects panel
-- **Meshes / VFX / SFX tabs** in a segmented style, with SFX coming from live
-  `listSoundGroups` and offering play plus focus
-- **Kind sections** — Sky, Water, Collision, Sub areas, Unplaced — with kind
-  search, denser rows and an inset list shell
-- Close only; the minimize control and footer are gone
+- **Meshes / VFX / SFX tabs**, with sound effects playable straight from the list
+- Objects grouped by kind — Sky, Water, Collision, Sub areas, Unplaced — with
+  search
 
 ### Effects and camera
-- **EffectActorsPanel** puts Character and NPC pickers under Effects, keeps the
-  loaded actor across views, and forces one F-style reset when leaving Zones for
-  Effects/PC/NPC
-- **Zone framing is FOV-aware**; entities and effects keep radius × 2.4, and **F
-  focuses the current selection**
-- **The camera F-resets on any Assets view switch**
+- Character and NPC pickers under Effects, so you can dress the actor without
+  leaving the page
+- Your loaded actor is kept when moving between views
+- Better zone framing, and **F** now focuses whatever you have selected
 
-### Data Struct
-- **Click-through tables for EffectRoutine, SpriteSheetMesh, ParticleMesh,
-  ParticleKeyFrameData and WeightedMesh**, with atlas textures paired beside
-  sheets and meshes
+### Settings and updates
+- Settings split into **General** and **XI Tools** tabs
+- More reliable update checks, with a clearer message when GitHub rate-limits you
+- Update checks now work in browser mode
+- Settings no longer reset themselves while you're typing in them
+- Grid and axes moved to the toolbar only
 
-### Settings, tools and updates
-- **Settings split into General and XI Tools tabs**, with `tools_status` reading
-  disk only and `tools_check_updates` doing the network call
-- **GitHub API plus HTML fallback** for release lookups, and clearer rate-limit
-  errors
-- **The app update check runs through Tauri / `serve.py`**, avoiding a
-  browser→GitHub CORS failure
-- **Settings no longer resets mid-edit** — the draft is snapshotted only when the
-  modal opens, not on every FPS re-render. Grid and axes moved to the toolbar only
-
-### Lists and search
-- **Shared Search fields on the NPC, Music and Sound Effects lists**, and every
-  left-hand list search unified onto the same inset text field (search icons and
-  Options rules dropped)
-- **HD no longer breaks weapon-skill animations** — schedule and motion packs
-  load from game/pivot only, skipping HD stubs, and focus paths match via
-  ROM-relative keys
-- Effects Actors gear slots expanded, with a close/status toggle and an NPC inset
-  shell
-- Right-rail padding and gap polish, and shared UI chrome throughout
+### Lists
+- **Search added to the NPC, Music and Sound Effects lists**, and every list
+  search now looks and works the same
+- Fixed HD installs breaking weapon-skill animations
+- Data Struct gained click-through tables for effect and particle data
 
 ---
 
@@ -325,146 +150,67 @@ Two fixes fell out of getting that on screen:
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.8...v1.0.9)
 
-### The app tells you when there's a new release
-- **A background release check on boot.** It asks GitHub for the newest published
-  release and, when it is newer than the running build, raises a dismissable
-  "Update available" notice with a link. Every failure path — offline,
-  rate-limited, timed out — resolves to nothing, so a failed check is invisible
-- **Nothing waits on it.** It runs from its own effect and is never awaited by
-  startup, and a zone-preview window skips the check entirely
-- **OK remembers the version**, so the notice stays gone until the next release
-  ships
-- **A green download CTA with the exe size**, and **File → Check for Updates**
-  with an up-to-date panel for checking on demand
+### Update notifications
+- The app now **checks for a new release on start** and shows a dismissable
+  notice with a link. It never holds up startup, and stays silent if you're
+  offline
+- A download button showing the file size, and **File → Check for Updates** to
+  look on demand
+- Dismissing remembers the version, so it stays gone until the next release
 
-### Effects play on your character, with the cast animation
-- **Actor-bound generators attach to the character's skeleton.** 91% of
-  generators in retail effect DATs are SourceActor/TargetActor and the joint is
-  already in the data (`attachedJoint0`) — joint 0 is only 54% of them, so a
-  fixed root attach would misplace the rest onto hands, head and feet
-- **Particles no longer come out mirrored against the actor.** Joint transforms
-  are handed over pre-multiplied by `DISPLAY_ROT`, which cancels the one applied
-  on the way out — otherwise particles sat at the reflection of their joint with
-  smoke sinking instead of rising
-- **"Show Character Animation" plays the caster's motion.** The cast is not the
-  0x05 op — it is a call to a schedule on the character's own DAT (`shbk` black,
-  `shnj` ninjutsu, `shwh` white) which `flattenRoutine` was discarding as
-  unresolvable. Every race ships those `sh*` schedules empty while the `ca*` twin
-  carries the ref, so the twin is read instead
-- **The effect is delayed so generators fire on the release frame**, and the cast
-  is one clip with `segments`, so SkeletonPose cross-fades back to idle over 0.3s
-- **Effect attach slots (0/1/21/43/48…) map to actor height** rather than raw
-  bones, so Stone V stays on the floor and Fire/Thunder sit on the body
-- **A full transport — Play / Pause / Rewind / Loop.** The old single button was
-  labelled Stop but only ever set `effectPaused`; a non-looping routine now parks
-  instead of tearing itself down, so Rewind and Play can replay it
-- **Returning from Effects to NPC/PC keeps the loaded actor** and restores list
-  selection state
-- **A schedule segment no longer drops one step early.** The release check was
-  `< 1`, so the last 1/`transOut` of the travel happened in a single frame — this
-  affects schedule playback generally, not just casts
+### Effects on your character
+- Effects now **play on a loaded character** rather than only an empty stage,
+  attached to the right body parts
+- **Show Character Animation** plays the caster's actual casting motion
+- Effects are timed to fire on the release frame and blend back to idle
+- Spells sit at the right height — Stone V on the floor, Fire and Thunder on
+  the body
+- Full **Play / Pause / Rewind / Loop** transport, replacing a single button
+  that couldn't replay anything
+- Leaving Effects keeps your actor and list selection
+- Fixed particles appearing mirrored and upside down on the character
+- Fixed the last part of a movement being skipped during schedules
 
-### New particle types
-- **0x22 Distortion** — a billboard quad that refracts a frozen scene grab by
-  `hazeOffset`, for heat haze and Utsusemi shimmer
-- **0x24 Ring** — a procedural ring built from `ringMeshParams`
-- **The opaque-snap hack no longer applies to effect shells.** Alpha-blended
-  *zone* particle meshes do snap past the halfway point (confirmed on Bibiki
-  Bay's ocean), but forcing a = 1 on a spell shell made Utsusemi's cage read as
-  solid and over-bright, so the snap is gated on association kind
+### New effect types
+- Heat haze and distortion effects now render, such as the Utsusemi shimmer
+- Ring effects now render
+- Fixed spell shells looking solid and over-bright
 
-### Viewport: backgrounds, floor and light
-- **Scene → Background Image**, backed by `ui/bgs/` and baked at build time. The
-  renderer draws it as a cover-fit full-screen quad after clear with depth off,
-  so models and floors sit on top; it is skipped when the skybox is on
-- **Backgrounds are cover-fit, not contain** — the clear colour used to show as
-  bars down the side of the canvas. Both scale factors stay ≤ 1 so the sampler
-  never reads outside [0,1]
-- **The floor fades out on a circle** instead of ending on a hard horizon.
-  Radial, not square, or the corners would reach further than the sides; the
-  fully-faded ring discards rather than writing depth
-- **Scene → Floor Repeat**, with the per-texture default and your multiplier kept
-  apart so picking a different floor re-derives the default without discarding
-  the setting
-- **Fixed a runaway canvas that read as being zoomed in.** `resize()` now
-  measures the window, not the canvas's own layout box — deriving the buffer from
-  `clientWidth` is self-referential, so buffer → layout → buffer grew every frame
-  until it pinned at 8192
-- **Entity shadows no longer clip on a hard diagonal.** Shadow maps are fitted to
-  the model's corners *plus* those corners dropped down the light onto the floor;
-  the old range came from model bounds alone, so past ~30° of sun elevation the
-  shadow's far end fell outside near/far
-- **A shadow light gizmo** (bottom-right, Shadows on only) overrides the
-  zone/entity sun direction for cast shadows; double-click resets and the
-  direction persists
-- **The light gizmo can reach the far hemisphere.** `hitDir` returned
-  `Math.sqrt(1 - d2)` for z, which is never negative, so dragging could only ever
-  aim the light in front of the model. A screen point maps to two directions, so
-  the second handle is the antipode, drawn mirrored through the centre;
-  right-dragging it negates the vector. The ray dashes when the light passes
-  behind
-- **Orbit after a pan pivots around the model** instead of snapping the view back
-- **The orbit pivot no longer overshoots small models.** Switching fly → orbit
-  dropped the pivot at least 5 units ahead of the camera, which suits a zone but
-  not an entity a couple of units across. The 5-unit floor is zones-only now
+### Viewport
+- **Scene → Background Image** — pick a backdrop for the viewport
+- Backgrounds now fill the viewport instead of leaving bars down the sides
+- The floor fades out in a circle rather than stopping at a hard edge
+- **Scene → Floor Repeat** to tile the floor texture
+- New **shadow light gizmo** for aiming the sun that casts your model's shadow;
+  double-click to reset. It can aim behind the model too
+- Fixed shadows being cut off by a hard diagonal line at higher sun angles
+- Fixed the view slowly zooming itself in over time
+- Orbiting after a pan no longer snaps the view back
+- Fixed the orbit point sitting past small models, so orbiting swung around
+  empty space
 
-### Data Struct and the DAT browser
-- **DAT Browser rows are labelled** — "Zone", "Gear", "Effect" — from data the
-  app already holds: the baked lists, the merged FTABLE map and the gear/zone-id
-  tables. A miss returns nothing rather than guessing
-- **`USER\<id>\` save files read properly.** They are not sectioned resource DATs
-  and previously fell through to the "not a sectioned DAT" card; `mcr.dat` /
-  `mcr<N>.dat` macro books and `mcr.ttl` / `mcr_2.ttl` book names now get real
-  layouts, everything else a hex/strings view
-- **A draggable table inspector** for SpellList (`mgc_`), AbilityList (`comm`)
-  and generic `mnc2`/`mon_`/`levc` tables
-- **XISTRING menu string tables** parse in the Data viewer with searchable
-  index/text rows — TOS and lobby help text, menu labels and so on
-- **XISTRING lengths and FA/ED control codes decode correctly** — u16 lengths
-  (the high word is flags), with runtime placeholders rendered as `{n}`/`{s}`/`{#}`
-  plus singular|plural forms and `{PS}`
+### Zones
+- Fixed a generic house interior being drawn on Mhaura's dock, along with about
+  300 other wrong or duplicated objects across every zone *(reported by Crevox)*
 
-### Zone fidelity
-- **Fuzzy mesh resolve no longer latches onto fourcc aliases.** Mhaura's
-  `ship_room` is a sub-area placeholder with no mesh of its own, but the fuzzy
-  pass normalised it to "shiproom", matched that tail against the 4-char
-  section-id alias `room`, and drew `room-hanyou` — a generic house interior — on
-  the dock, where nothing renders in game. Fuzzy matching is now restricted to
-  real 0x2E mesh names. Across all 601 zone DATs this changes 306 of 1,106,615
-  placements: 296 phantom or duplicate draws dropped, and 10 `id_bus_path`
-  placements corrected from the fourcc `path` to the real mesh `bus_path`
-  *(reported by Crevox)*
+### Data
+- DAT Browser rows are **labelled by type** — Zone, Gear, Effect — so you can
+  tell what a file is without opening it
+- **Save files are readable** — macro books show as proper macro lists
+- **Menu and system text (XISTRING)** is readable and searchable, with
+  placeholders and plurals shown properly
+- A draggable table viewer for spell and ability lists
 
-### UI plumbing
-- **The Graphics modal became a toolbar popover** — resolution scale, shadow
-  distance and FPS cap now use the same chrome as the FOV and Scene popovers, and
-  `GraphicsModal.jsx` is gone. One less full-screen modal for settings you tweak
-  while looking at the viewport
-- **A Scene popover** for background and floor, next to Graphics
-- **Native `title` tooltips moved onto Tippy** across 19 panels and modals,
-  keeping existing aria-labels for accessibility
-- **The settings modal was reworked**, and **Open notes file moved into Settings**
-- **Tippy raised above modals**, with tighter UiMenu/UiElementGroup notes wiring
-- **The tools bridge is exposed to the UI** — the `src-tauri` tools command
-  surface plus the `toolsBoot`/backend hooks the front end calls through
-- The last effect is restored on boot; empty-stage axes orientation fixed;
-  grid/axes preferences kept
+### Interface
+- Graphics settings moved from a full-screen modal to a toolbar popover
+- A new Scene popover for background and floor
+- The settings window was reworked, and Open notes file moved into it
+- Tooltips unified and now appear above windows instead of behind them
+- Your last effect is restored on start, and grid/axes settings are remembered
 
-### Build and lists
-- **Background images ship once, not twice.** `ui/public/bgs/` held a
-  byte-identical second copy of every background — Vite bundled `ui/bgs/` through
-  the glob *and* copied `public/` verbatim, costing 2.6 MB of the build
-- **Baked entries carry only `path`.** Effect entries duplicated their DAT
-  location as `dir` + `file` alongside the full path; `EffectList` now derives the
-  `15/89` badge from the path, so search matches either form
-- **Placeholder duplicates dropped from the lists.** The upstream CSVs list some
-  DATs twice — once named, once blank — and the baker turned the blank row into a
-  "181/55" placeholder that read as a second effect sitting under the real one.
-  Two genuine names for one DAT (Corsair's 164/61 is both Dancer's Roll and
-  Double-Up) are left alone
-- Baked lists now emit 1-space indent to match each other, so a rebake is a small
-  diff rather than a 35k-line reformat
-- Dropped the dead `did_sync` flag in setup
+### Under the hood
+- Background images no longer ship twice, saving 2.6 MB from the download
+- Fixed duplicate blank entries appearing underneath real effects in the list
 
 ---
 
@@ -473,107 +219,73 @@ Two fixes fell out of getting that on screen:
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.5...v1.0.8)
 
 ### Open a zone straight from another tool
-- **`--zone` launch** — `xi-model-viewer.exe --zone "ROM/171/34.DAT"` starts the
-  viewer already showing that zone, so a zone editor's Preview button, a shortcut
-  or a shell can hand off to it
-- **Minimal by default** — viewport plus the Zone panel (weather, time of day,
-  fog, brightness, background, BGM/ambient volume) and nothing else; **`--full-ui`**
-  opens the same zone in the whole app
-- **`--weather`, `--time`, `--clock`** set the scene up front, and the window
+- **`--zone` launch** — `xi-model-viewer.exe --zone "ROM/171/34.DAT"` opens the
+  viewer already showing that zone, so a zone editor's Preview button or a
+  shortcut can hand off to it
+- Opens **minimal by default** — just the viewport and the Zone panel. Use
+  `--full-ui` for the whole app
+- `--weather`, `--time` and `--clock` set the scene up front, and the window
   title becomes the zone name
-- **Takes the path you have** — game-relative, a leveleditor `game/ROM/…` path,
-  the DAT's absolute path (game or HD root), or a zone id; unlisted prototype
-  DATs still open by path
-- **A preview is a side trip** — it doesn't overwrite your last-opened DAT,
-  doesn't change the page the full app restores to, and doesn't eat the
-  first-launch About greeting. Launched before a game path was ever set, it asks
-  for one and then opens your zone instead of the demo model
-- **One parser covers both shells** — a `launch_args` command hands the process
-  argv to the frontend, and browser dev mode takes the same options as a query
-  string (`?zone=…&time=18:00`)
+- Takes whatever path you have — game-relative, absolute, or a zone id
+- A preview is a side trip: it won't overwrite the session the full app returns
+  to next time
+- Browser dev mode takes the same options as a query string
 
-### Title UI: inspect, edit, save
-- **UiMenu (0x30) windows** — frame and child buttons as a draggable table:
-  position, size and Up/Down/Left/Right nav
-- **Edit and save back** — patch x/y/w/h and nav through `xi title menu`
-  (xi-tools); the DAT reloads with edit mode intact so you can keep iterating
-- **Writes land in the right root** — pivot (Ashita / override), HD, or game,
-  resolved per DAT
-- **UiElementGroup (0x31) inspector** — set header plus sprite layout rows
-  (owner / parent / dest / src), same chrome as the menu window
-- **Console output panel** — bottom-left dump of what `xi` actually printed,
-  optional auto-close with a countdown
-- **Settings** — xi-tools folder, setup helper, and toggles for the console panel
-- Backend `xi_run` / `xi_setup` helpers, and modal z-ordering so the new windows
-  stack sanely
+### Title UI editing
+- **Inspect UiMenu windows** — the frame and its buttons as a table of
+  positions, sizes and navigation
+- **Edit and save back to the DAT** through xi-tools, with the file reloading so
+  you can keep iterating
+- Changes are written to the right place — pivot, HD or game — worked out per file
+- **UiElementGroup inspector** for sprite layouts
+- A console panel showing what the tool actually did, with optional auto-close
+- Settings for the xi-tools folder, a setup helper, and console toggles
 
-### Notes on anything
-- **Free-text notes per DAT and per UiMenu**, stored in
-  `%LOCALAPPDATA%\XiModelViewer\notes.json` — plain, portable, editable outside
-  the app
-- **File tree tooltips show the note**, so a folder of numbered DATs stops being
-  anonymous
-- Unsaved typing survives a DAT reload; optional close-on-save for the whole-DAT
-  Notes window
+### Notes
+- **Write free-text notes on any DAT**, saved to a plain file you can edit
+  outside the app
+- **The file tree shows your note as a tooltip**, so a folder of numbered files
+  stops being anonymous
+- Unsaved typing survives reloading the file
 
-### Images and sprites
-- **Title / lobby packs read properly** — `lobb` packs (a few 0x20 textures plus
-  one giant 0x31 layout blob) used to show a single broken set and hide the local
-  textures; those textures are now surfaced and the blob is parsed into sprite
-  rows
-- **Sprite panel** under Images — every sprite in the layout, filtered to the
-  atlas you have selected, searchable
-- Bare 0x20 textures no set claims (logos, `wardrb`) are listed instead of dropped
+### Images
+- **Title and lobby image packs now load properly** — they used to show one
+  broken set and hide everything else
+- **New sprite panel** listing every sprite in a layout, filtered to the image
+  you have selected, with search
+- Loose textures that no set claimed (logos and similar) are now listed instead
+  of dropped
 
 ### Data Struct
-- **Bump maps (0x5D)** decode as height fields and preview as tangent-space
-  normal maps
-- **Routes (0x06)** open as a keyframe table — camera paths from scene DATs, with
-  focal length shown as FOV
-- **Companion tabs always there** — empty event / NPC / dialog DATs still get a
-  tab, so the chrome stops collapsing as you switch
-- **Dialog by event or as flat lines**, with search across both; NPC rows show
-  record and target index
-- Texture modals centre themselves
+- **Bump maps** preview as normal maps
+- **Routes** open as a keyframe table — camera paths from cutscene files
+- Event, NPC and dialog tabs stay put even when empty, so the layout stops
+  jumping around
+- Dialog can be read by event or as flat lines, with search across both
 
 ### Objects panel
-- **Meshes and Visual Effects tabs** — the VFX catalog lists zone-owned effects
-  and the weather folder each one sits under, built from the full DAT tree rather
-  than only live generators
-- **Per-object and per-group visibility toggles**, with hidden and moved state
-  marked on the row and reset on moved rows only
-- Sky and water listed only when Toggle Skybox is on; unplaced objects always
-  listed; the chosen tab persists
+- **Meshes and Visual Effects tabs**, listing the zone's effects and which
+  weather they belong to
+- **Show and hide individual objects or whole groups**, with moved and hidden
+  rows marked
 
-### File browser
-- **Pin favourites** — pinned files sit in a folder at the top and open without
-  yanking the tree back to their original path
-- Multiple top-level roots, each with its own label
+### File browser and zones
+- **Pin favourite files** — they sit in a folder at the top and open without
+  yanking the tree back
+- **New Dev / XI Modified zone group** covering the 22 custom dev zones,
+  identified by matching their contents rather than guessing from slot order
+- Two more prototype zones added, and stale entries removed
+- Fixed zone groups sorting into the wrong place
 
-### Zone list
-- **Dev / XI Modified group** — the 22 custom ROM10/100 dev zones (405–426),
-  named by matching each zone's placement signature against the prototype sources
-  rather than slot order, which is how 407 turned out to be Character Creation
-  from ROM/1/5 rather than a ROM/0/* prototype
-- **Sunny castle town and windmill town prototypes (403, 404)** added; stale
-  408/413 entries dropped
-- **Group ordering fixed** — curated groups were pinned to the bottom by a
-  hardcoded `TAIL_GROUPS` list, so a new group fell through to the ROM-number
-  comparator, where `+a.slice(3) || 1` gives NaN → 1 and it sorted next to ROM
-  (base). Anything matching `ROM<n>` now sorts by number and everything else tails
-  alphabetically, so a future group needs no code change
-
-### Prototype zones and the Camera Sequencer
-- **Better prototype rendering** — prefer the richer of duplicate meshes, planar
-  two-sided doors, particle-owned mills with spinning `w_mill` companions, an
-  unplaced toggle, and sky / enclosing shells skipped when casting shadows
-- **Time track in the sequencer** — a 25px track with lerped time of day, a
-  smooth time-only lighting path that doesn't rebuild the scene, and a rAF-driven
-  day clock
+### Prototype zones and the sequencer
+- Better prototype rendering — two-sided doors, spinning windmills, and better
+  choices between duplicate meshes
+- **Time track in the Camera Sequencer** — change time of day across a shot, with
+  smooth lighting that doesn't rebuild the scene
 
 ### Settings
-- **Game, HD and pivot paths** in one column
-- **Auto-switch to WASD on zone load** (fly camera: WASD / QE / Shift / wheel)
+- Game, HD and pivot paths all in one place
+- Auto-switch to WASD flying when a zone loads
 
 ---
 
@@ -581,57 +293,37 @@ Two fixes fell out of getting that on screen:
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.4...v1.0.5)
 
-### Zones that actually work as a toolkit
-- **Data Struct knows the whole zone bundle** — mesh, events, dialog and NPCs as
-  related DATs, kept in sync as you change zone
-- **ZoneDef browser** — a placements table you can open, search and click through,
-  including ParticleGenerators
-- **In-modal particle preview** — play generators without hijacking the main
-  viewport; resize, grid and background colour
-- **Live Selection** — click objects in the world, hover/select wireframes, drag a
-  solid XYZ gizmo for in-memory moves, with undo and reset on moved rows only
-- **Converted / prototype zones** — a score-first 0x54 vs 0x64 placement stride so
-  patched DATs don't shred object lists
-- **A1R5G5B5 palette decode** so prototype textures stop looking like green
-  static. Paletted-texture headers carry bits-per-palette-entry in the final dword
-  of the 40-byte BITMAPINFOHEADER — 0x20 = 32-bit BGRA (1024 bytes), 0x10 =
-  16-bit A1R5G5B5 (512) — and both decoders read that field then discarded it and
-  hardcoded a 256 × u32 palette, which on a 0x10 texture scrambles the colours and
-  shifts every pixel by 512 bytes. That was the bright-green speckle covering Dev
-  Castle Town (`rom/0/33`). Retail content is always 0x20, so nothing else changes
-- **Pin favourite zones** — hover → pin; pinned maps sit in a folder at the top of
-  the list and persist in localStorage
-- **FPS limit options**
+### Zones
+- **Data Struct understands the whole zone bundle** — mesh, events, dialog and
+  NPCs together
+- **ZoneDef browser** — a searchable, clickable table of everything placed in
+  the zone
+- **Particle preview in a window** so you can play generators without taking
+  over the viewport
+- **Live Selection** — click objects in the world and drag them on an XYZ gizmo,
+  with undo
+- **Fixed prototype zones showing bright green static** instead of their real
+  textures
+- Better handling of converted and patched zone files, so object lists stop
+  coming out garbled
+- **Pin favourite zones** to a folder at the top of the list
+- FPS limit options
 
 ### Camera Sequencer
-- Two-track timeline (Camera + Scene), record at the playhead, scrub, multi-select
-  and group drag
-- Snap, path **Curve**, Space play/pause, a compact transport bar, zoom and wheel
-  pan on the timeline
-- Fixed-height panel, width-only resize, **New** sequence; Tippy tooltips
-  throughout
+- Two-track timeline (Camera and Scene) — record keyframes, scrub, and drag
+  several at once
+- Snapping, curved paths, Space to play/pause, and zoom and pan on the timeline
+- A compact transport bar and a **New** sequence button
 
-### Gear, files, and camera behaviour
-- **Gear + race skeleton resolved from FTABLE / gear tables first**, with the
-  binary name sniff demoted to a scored fallback — a digit-prefixed tag (`70hm`)
-  now beats a `_slot` suffix (`hm_m`), where before a bare `hf` substring in
-  random binary noise could pick the wrong skeleton and put male boots on a HumeF
-- **Data Struct keeps every character slot** in the DAT dropdown when you inspect
-  a piece
-- **File tree collapse sticks** — folders don't re-expand every frame. A folder you
-  closed stays closed, and reveal auto-expand only fires when the target *changes*
-  to something beneath it
-- **Show in Explorer fixed for paths with spaces** (`Program Files (x86)`, etc.).
-  Explorer's `/select` parsing splits a single `/select,C:\…` argument on spaces
-  and dumps you in Documents, so the flag and the path go in as two separate argv
-  entries, with the `\\?\` prefix from `canonicalize` stripped
-- **Camera stays put** after you've orbited, panned or zoomed when loading the
-  next entity DAT
-- Auto-play idle is **off by default** (still available in Settings)
-
-### Quality of life
-- Tippy-only tooltips for UI hover text
-- Cleaner status/path flows around inspect ↔ 3D
+### Fixes
+- **Gear now picks the right race skeleton**, instead of occasionally putting
+  male boots on a female model
+- **Folders you collapse stay collapsed** rather than re-opening constantly
+- **Show in Explorer works for paths with spaces**, instead of dumping you in
+  Documents
+- **The camera stays where you put it** when loading the next model
+- Data Struct keeps every character slot listed when inspecting gear
+- Auto-play idle is now off by default
 
 ---
 
@@ -639,16 +331,14 @@ Two fixes fell out of getting that on screen:
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.3...v1.0.4)
 
-- **Multi-DAT Data Struct inspection** — dropdowns for characters and creation,
-  RT/SHAPE/DMB/SQLE inspectors, and structure search
-- **Gear** — auto skeleton pairing and per-slot mesh isolation
+- **Inspect multi-file assets** in Data Struct, with dropdowns for characters
+  and character creation
+- **Gear pairs itself with the right skeleton**, and individual slots can be
+  isolated
 - **Clickable texture and skeleton rows**, with a floating skeleton tree
-- **SoundEffectPointer playback** — play a row once with a spinning icon, click to
-  stop
-- **Path links open in the OS file manager**, and path jumps land in the File
-  Browser
-- Status bar split into left/right pills; orbit controls restored after toggling
-  the creation cinematic camera
+- **Play sound effects from the structure view**, click again to stop
+- **Path links open in your file manager**, and jump into the File Browser
+- Structure search, and a status bar split into left and right
 
 ---
 
@@ -656,12 +346,11 @@ Two fixes fell out of getting that on screen:
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.2...v1.0.3)
 
-- **Character creation faces** — expanded to 8, with A/B DMB variants
-- **Equipment mesh stays put** instead of dropping on reload
-- **SQLE animation playback** — PB sequences play as authored absolute poses,
-  including floor staging
-- **Prefix-channel locomotion** on equip bodies such as Mithra
-- Curated zone groups sort after ROM folders
+- **Character creation faces expanded to 8**, with A/B variants
+- **Equipment no longer disappears** when reloading
+- **Character creation animations play properly**, including their floor staging
+- Fixed walking animations on Mithra and similar bodies
+- Curated zone groups now sort after the ROM folders
 
 ---
 
@@ -669,18 +358,14 @@ Two fixes fell out of getting that on screen:
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.1...v1.0.2)
 
-- **Smart-open DATs by type** — zone, model, image, audio, effect, data — with
-  path search and selection highlight in the File Browser
-- **Falls back to the structure inspector** with a clear notice when a file can't
-  be drawn
-- **Pre-production MZB zones parse** — multi-group meshes, 0x54 placements,
-  strips, blank names — so maps like ROM/0/41 and 46 load more completely
-- Additional texture types decoded; structure Texture rows are clickable
-- Status-bar Data Struct toggle, and WASD stays on for zones opened from the
-  browser
-- Build fix: `beforeBuildCommand` no longer looks for `ui/ui` — it uses an
-  explicit cwd of `../ui` with `npm run build` instead of the dual `--prefix`
-  fallback that errored when Tauri already ran from the `ui` tree
+- **Open any DAT and get the right viewer** — zone, model, image, audio, effect
+  or data — with path search and selection highlighting
+- **Falls back to the structure inspector** with a clear message when a file
+  can't be drawn
+- **Pre-production zones now load**, so early maps come out far more complete
+- More texture types decoded, and texture rows are clickable
+- Data Struct toggle on the status bar, and WASD stays on for zones
+- Fixed the release build looking in the wrong folder
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,31 +13,22 @@ Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.12...v1.1.0)
 
 ### Animation
-- Anim, Schedule and Skill are now a single **Motion** dropdown, grouped into
-  Animations, Schedules and Specials, so it's clear what's playing
-- New **Base** setting (None / Idle / Battle) plays your clip on top of a
-  resting pose, blending in and out of it — so a loop reads as "rest, do the
-  thing, rest". Off by default
-- Fixed: after playing a skill pack, picking a normal animation replayed the
-  pack's effects and sound over it
+- Anim, Schedule and Skill are now a single **Motion** dropdown, grouped into Animations, Schedules and Specials, so it's clear what's playing
+- New **Base** setting (None / Idle / Battle) plays your clip on top of a resting pose, blending in and out of it — so a loop reads as "rest, do the thing, rest". Off by default
+- Fixed: after playing a skill pack, picking a normal animation replayed the pack's effects and sound over it
 - NPC panel rows reordered to a more sensible order
 
 ### Camera and floor
-- The floor no longer moves with the model. It used to shift with every
-  animation, which looked like the camera was dropping through it
-- Selecting another actor no longer throws away your camera angle. Turn it back
-  on with Settings → Reframe camera on Actor Selection
-- Outside of zones, the mouse wheel now zooms towards the centre instead of your
-  cursor, so the model doesn't drift off-screen
+- The floor no longer moves with the model. It used to shift with every animation, which looked like the camera was dropping through it
+- Selecting another actor no longer throws away your camera angle. Turn it back on with Settings → Reframe camera on Actor Selection
+- Outside of zones, the mouse wheel now zooms towards the centre instead of your cursor, so the model doesn't drift off-screen
 
 ### Camera Sequencer
 - **Lock to Actor** now tracks the actor's hips, so jumps and steps stay in shot
-- Scrubbing and stopping hand the camera back in whatever mode you were using,
-  instead of leaving you in fly mode
+- Scrubbing and stopping hand the camera back in whatever mode you were using, instead of leaving you in fly mode
 
 ### Scene and settings
-- Settings → **Day Length** — how many real seconds an in-game day takes
-  (default 60)
+- Settings → **Day Length** — how many real seconds an in-game day takes (default 60)
 - Weather and time controls now appear for any zone that has weather
 - Navmesh can be loaded from your own folder (Settings → Navmesh Folder)
 - Two new backgrounds: Clouds and Rhapsody
@@ -62,46 +53,35 @@ Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.10...v1.0.12)
 
 ### NPCs
-- NPCs can now play their **own visual effects**, with the Both / Mesh / VFX
-  control and an effect volume slider
-- Pick which effect plays from a new **Effect** dropdown. Previously a random
-  one fired on every animation
-- New **Skill** dropdown loads the animation packs a trust borrows, so you can
-  play their special moves
+- NPCs can now play their **own visual effects**, with the Both / Mesh / VFX control and an effect volume slider
+- Pick which effect plays from a new **Effect** dropdown. Previously a random one fired on every animation
+- New **Skill** dropdown loads the animation packs a trust borrows, so you can play their special moves
 - Fixed NPC textures being repainted when their effects loaded
 - Fixed models hovering slightly above the floor
 
 ### Animation
-- PC battle and weapon-skill animations now load their full-body packs, so
-  they animate properly instead of only partly
-- Bows and other ranged weapons now stay stowed unless the animation actually
-  uses them, instead of hanging in view through every sword swing
+- PC battle and weapon-skill animations now load their full-body packs, so they animate properly instead of only partly
+- Bows and other ranged weapons now stay stowed unless the animation actually uses them, instead of hanging in view through every sword swing
 - Fixed a one-frame jolt in the middle of weapon skills like Eagle Eye Shot
 
 ### Camera Sequencer
-- **Lock to Actor** — keyframes record facing the actor, and playback keeps them
-  in frame
+- **Lock to Actor** — keyframes record facing the actor, and playback keeps them in frame
 - Effects and sound now play back with your shot, instead of it being silent
 - Play always starts from the top, and rewinds the actor with it
 - Reaching the end rewinds to the start
 - Pressing Play at the end of a clip now rewinds instead of doing nothing
 - Scrubbing gives you a normal orbit camera back
-- Your work survives closing the panel — named sequences are still saved
-  separately
+- Your work survives closing the panel — named sequences are still saved separately
 
 ### Scene
-- Scene → **Flat Floor** — a plain coloured ground plane with a colour picker,
-  kept separate from a loaded floor so switching loses nothing
+- Scene → **Flat Floor** — a plain coloured ground plane with a colour picker, kept separate from a loaded floor so switching loses nothing
 
 ### Browsing and viewers
 - Fixed DAT Browser search getting stuck on "Building file index…" forever
-- Gear sets now come from the list data, so new sets appear without an update.
-  Adds Abjuration and the Mythic, Aeonic and Prime weapons, and merges Ebur,
-  Furia and Ebon into one section
+- Gear sets now come from the list data, so new sets appear without an update. Adds Abjuration and the Mythic, Aeonic and Prime weapons, and merges Ebur, Furia and Ebon into one section
 - Odds and ends in the weapon lists now group under a single "Other" heading
 - Images are labelled UI, Cutscene or Map rather than everything being "Map"
-- Texture and image viewers remember your background colour and support zoom
-  and pan
+- Texture and image viewers remember your background colour and support zoom and pan
 - Skeleton animation and info rows can be inspected in Data Struct
 - Ctrl + left mouse now pans
 
@@ -112,22 +92,18 @@ Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.9...v1.0.10)
 
 ### Zones
-- **Region culling** (View → Region Culling) draws only what the zone says is
-  visible from where you're standing
-- Invisible collision blocks and duplicate distant copies are now hidden, fixing
-  the flickering surfaces in Ru'Aun Gardens
+- **Region culling** (View → Region Culling) draws only what the zone says is visible from where you're standing
+- Invisible collision blocks and duplicate distant copies are now hidden, fixing the flickering surfaces in Ru'Aun Gardens
 - Fixed the wrong mesh being drawn in Dynamis and roughly 69 other zones
 - Live Selection can now pick sub-area, unplaced and collision objects
 - The ZoneDef list shows which sub-area an object belongs to
 
 ### Objects panel
 - **Meshes / VFX / SFX tabs**, with sound effects playable straight from the list
-- Objects grouped by kind — Sky, Water, Collision, Sub areas, Unplaced — with
-  search
+- Objects grouped by kind — Sky, Water, Collision, Sub areas, Unplaced — with search
 
 ### Effects and camera
-- Character and NPC pickers under Effects, so you can dress the actor without
-  leaving the page
+- Character and NPC pickers under Effects, so you can dress the actor without leaving the page
 - Your loaded actor is kept when moving between views
 - Better zone framing, and **F** now focuses whatever you have selected
 
@@ -139,8 +115,7 @@ Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 - Grid and axes moved to the toolbar only
 
 ### Lists
-- **Search added to the NPC, Music and Sound Effects lists**, and every list
-  search now looks and works the same
+- **Search added to the NPC, Music and Sound Effects lists**, and every list search now looks and works the same
 - Fixed HD installs breaking weapon-skill animations
 - Data Struct gained click-through tables for effect and particle data
 
@@ -151,22 +126,16 @@ Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.8...v1.0.9)
 
 ### Update notifications
-- The app now **checks for a new release on start** and shows a dismissable
-  notice with a link. It never holds up startup, and stays silent if you're
-  offline
-- A download button showing the file size, and **File → Check for Updates** to
-  look on demand
+- The app now **checks for a new release on start** and shows a dismissable notice with a link. It never holds up startup, and stays silent if you're offline
+- A download button showing the file size, and **File → Check for Updates** to look on demand
 - Dismissing remembers the version, so it stays gone until the next release
 
 ### Effects on your character
-- Effects now **play on a loaded character** rather than only an empty stage,
-  attached to the right body parts
+- Effects now **play on a loaded character** rather than only an empty stage, attached to the right body parts
 - **Show Character Animation** plays the caster's actual casting motion
 - Effects are timed to fire on the release frame and blend back to idle
-- Spells sit at the right height — Stone V on the floor, Fire and Thunder on
-  the body
-- Full **Play / Pause / Rewind / Loop** transport, replacing a single button
-  that couldn't replay anything
+- Spells sit at the right height — Stone V on the floor, Fire and Thunder on the body
+- Full **Play / Pause / Rewind / Loop** transport, replacing a single button that couldn't replay anything
 - Leaving Effects keeps your actor and list selection
 - Fixed particles appearing mirrored and upside down on the character
 - Fixed the last part of a movement being skipped during schedules
@@ -181,24 +150,19 @@ Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 - Backgrounds now fill the viewport instead of leaving bars down the sides
 - The floor fades out in a circle rather than stopping at a hard edge
 - **Scene → Floor Repeat** to tile the floor texture
-- New **shadow light gizmo** for aiming the sun that casts your model's shadow;
-  double-click to reset. It can aim behind the model too
+- New **shadow light gizmo** for aiming the sun that casts your model's shadow; double-click to reset. It can aim behind the model too
 - Fixed shadows being cut off by a hard diagonal line at higher sun angles
 - Fixed the view slowly zooming itself in over time
 - Orbiting after a pan no longer snaps the view back
-- Fixed the orbit point sitting past small models, so orbiting swung around
-  empty space
+- Fixed the orbit point sitting past small models, so orbiting swung around empty space
 
 ### Zones
-- Fixed a generic house interior being drawn on Mhaura's dock, along with about
-  300 other wrong or duplicated objects across every zone *(reported by Crevox)*
+- Fixed a generic house interior being drawn on Mhaura's dock, along with about 300 other wrong or duplicated objects across every zone *(reported by Crevox)*
 
 ### Data
-- DAT Browser rows are **labelled by type** — Zone, Gear, Effect — so you can
-  tell what a file is without opening it
+- DAT Browser rows are **labelled by type** — Zone, Gear, Effect — so you can tell what a file is without opening it
 - **Save files are readable** — macro books show as proper macro lists
-- **Menu and system text (XISTRING)** is readable and searchable, with
-  placeholders and plurals shown properly
+- **Menu and system text (XISTRING)** is readable and searchable, with placeholders and plurals shown properly
 - A draggable table viewer for spell and ability lists
 
 ### Interface
@@ -219,69 +183,50 @@ Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.5...v1.0.8)
 
 ### Open a zone straight from another tool
-- **`--zone` launch** — `xi-model-viewer.exe --zone "ROM/171/34.DAT"` opens the
-  viewer already showing that zone, so a zone editor's Preview button or a
-  shortcut can hand off to it
-- Opens **minimal by default** — just the viewport and the Zone panel. Use
-  `--full-ui` for the whole app
-- `--weather`, `--time` and `--clock` set the scene up front, and the window
-  title becomes the zone name
+- **`--zone` launch** — `xi-model-viewer.exe --zone "ROM/171/34.DAT"` opens the viewer already showing that zone, so a zone editor's Preview button or a shortcut can hand off to it
+- Opens **minimal by default** — just the viewport and the Zone panel. Use `--full-ui` for the whole app
+- `--weather`, `--time` and `--clock` set the scene up front, and the window title becomes the zone name
 - Takes whatever path you have — game-relative, absolute, or a zone id
-- A preview is a side trip: it won't overwrite the session the full app returns
-  to next time
+- A preview is a side trip: it won't overwrite the session the full app returns to next time
 - Browser dev mode takes the same options as a query string
 
 ### Title UI editing
-- **Inspect UiMenu windows** — the frame and its buttons as a table of
-  positions, sizes and navigation
-- **Edit and save back to the DAT** through xi-tools, with the file reloading so
-  you can keep iterating
+- **Inspect UiMenu windows** — the frame and its buttons as a table of positions, sizes and navigation
+- **Edit and save back to the DAT** through xi-tools, with the file reloading so you can keep iterating
 - Changes are written to the right place — pivot, HD or game — worked out per file
 - **UiElementGroup inspector** for sprite layouts
 - A console panel showing what the tool actually did, with optional auto-close
 - Settings for the xi-tools folder, a setup helper, and console toggles
 
 ### Notes
-- **Write free-text notes on any DAT**, saved to a plain file you can edit
-  outside the app
-- **The file tree shows your note as a tooltip**, so a folder of numbered files
-  stops being anonymous
+- **Write free-text notes on any DAT**, saved to a plain file you can edit outside the app
+- **The file tree shows your note as a tooltip**, so a folder of numbered files stops being anonymous
 - Unsaved typing survives reloading the file
 
 ### Images
-- **Title and lobby image packs now load properly** — they used to show one
-  broken set and hide everything else
-- **New sprite panel** listing every sprite in a layout, filtered to the image
-  you have selected, with search
-- Loose textures that no set claimed (logos and similar) are now listed instead
-  of dropped
+- **Title and lobby image packs now load properly** — they used to show one broken set and hide everything else
+- **New sprite panel** listing every sprite in a layout, filtered to the image you have selected, with search
+- Loose textures that no set claimed (logos and similar) are now listed instead of dropped
 
 ### Data Struct
 - **Bump maps** preview as normal maps
 - **Routes** open as a keyframe table — camera paths from cutscene files
-- Event, NPC and dialog tabs stay put even when empty, so the layout stops
-  jumping around
+- Event, NPC and dialog tabs stay put even when empty, so the layout stops jumping around
 - Dialog can be read by event or as flat lines, with search across both
 
 ### Objects panel
-- **Meshes and Visual Effects tabs**, listing the zone's effects and which
-  weather they belong to
-- **Show and hide individual objects or whole groups**, with moved and hidden
-  rows marked
+- **Meshes and Visual Effects tabs**, listing the zone's effects and which weather they belong to
+- **Show and hide individual objects or whole groups**, with moved and hidden rows marked
 
 ### File browser and zones
-- **Pin favourite files** — they sit in a folder at the top and open without
-  yanking the tree back
-- **New Dev / XI Modified zone group** covering the 22 custom dev zones,
-  identified by matching their contents rather than guessing from slot order
+- **Pin favourite files** — they sit in a folder at the top and open without yanking the tree back
+- **New Dev / XI Modified zone group** covering the 22 custom dev zones, identified by matching their contents rather than guessing from slot order
 - Two more prototype zones added, and stale entries removed
 - Fixed zone groups sorting into the wrong place
 
 ### Prototype zones and the sequencer
-- Better prototype rendering — two-sided doors, spinning windmills, and better
-  choices between duplicate meshes
-- **Time track in the Camera Sequencer** — change time of day across a shot, with
-  smooth lighting that doesn't rebuild the scene
+- Better prototype rendering — two-sided doors, spinning windmills, and better choices between duplicate meshes
+- **Time track in the Camera Sequencer** — change time of day across a shot, with smooth lighting that doesn't rebuild the scene
 
 ### Settings
 - Game, HD and pivot paths all in one place
@@ -294,33 +239,24 @@ Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.4...v1.0.5)
 
 ### Zones
-- **Data Struct understands the whole zone bundle** — mesh, events, dialog and
-  NPCs together
-- **ZoneDef browser** — a searchable, clickable table of everything placed in
-  the zone
-- **Particle preview in a window** so you can play generators without taking
-  over the viewport
-- **Live Selection** — click objects in the world and drag them on an XYZ gizmo,
-  with undo
-- **Fixed prototype zones showing bright green static** instead of their real
-  textures
-- Better handling of converted and patched zone files, so object lists stop
-  coming out garbled
+- **Data Struct understands the whole zone bundle** — mesh, events, dialog and NPCs together
+- **ZoneDef browser** — a searchable, clickable table of everything placed in the zone
+- **Particle preview in a window** so you can play generators without taking over the viewport
+- **Live Selection** — click objects in the world and drag them on an XYZ gizmo, with undo
+- **Fixed prototype zones showing bright green static** instead of their real textures
+- Better handling of converted and patched zone files, so object lists stop coming out garbled
 - **Pin favourite zones** to a folder at the top of the list
 - FPS limit options
 
 ### Camera Sequencer
-- Two-track timeline (Camera and Scene) — record keyframes, scrub, and drag
-  several at once
+- Two-track timeline (Camera and Scene) — record keyframes, scrub, and drag several at once
 - Snapping, curved paths, Space to play/pause, and zoom and pan on the timeline
 - A compact transport bar and a **New** sequence button
 
 ### Fixes
-- **Gear now picks the right race skeleton**, instead of occasionally putting
-  male boots on a female model
+- **Gear now picks the right race skeleton**, instead of occasionally putting male boots on a female model
 - **Folders you collapse stay collapsed** rather than re-opening constantly
-- **Show in Explorer works for paths with spaces**, instead of dumping you in
-  Documents
+- **Show in Explorer works for paths with spaces**, instead of dumping you in Documents
 - **The camera stays where you put it** when loading the next model
 - Data Struct keeps every character slot listed when inspecting gear
 - Auto-play idle is now off by default
@@ -331,10 +267,8 @@ Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.3...v1.0.4)
 
-- **Inspect multi-file assets** in Data Struct, with dropdowns for characters
-  and character creation
-- **Gear pairs itself with the right skeleton**, and individual slots can be
-  isolated
+- **Inspect multi-file assets** in Data Struct, with dropdowns for characters and character creation
+- **Gear pairs itself with the right skeleton**, and individual slots can be isolated
 - **Clickable texture and skeleton rows**, with a floating skeleton tree
 - **Play sound effects from the structure view**, click again to stop
 - **Path links open in your file manager**, and jump into the File Browser
@@ -358,10 +292,8 @@ Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.1...v1.0.2)
 
-- **Open any DAT and get the right viewer** — zone, model, image, audio, effect
-  or data — with path search and selection highlighting
-- **Falls back to the structure inspector** with a clear message when a file
-  can't be drawn
+- **Open any DAT and get the right viewer** — zone, model, image, audio, effect or data — with path search and selection highlighting
+- **Falls back to the structure inspector** with a clear message when a file can't be drawn
 - **Pre-production zones now load**, so early maps come out far more complete
 - More texture types decoded, and texture rows are clickable
 - Data Struct toggle on the status bar, and WASD stays on for zones

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,104 +4,653 @@ All notable changes to XI Model Viewer.
 
 Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 
+Version numbers follow the tags that were actually published — 1.0.6, 1.0.7 and
+1.0.11 were never released, so they have no entry here.
+
+---
+
+## [1.1.0] — 2026-09-01
+
+[Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.12...v1.1.0)
+
+### One Motion picker instead of three
+- **Anim, Schedule and Skill are now a single Motion dropdown**, grouped into
+  Animations / Schedules / Specials, so it is always obvious which one is
+  playing. Ids carry an internal prefix because a schedule and a clip can share
+  a name; a Special stays the shown selection while its own clip runs, rather
+  than flipping over to the entry it added under Animations
+- **NPC panel rows reordered** to Show, Motion, Effect, Playback, Frame, Speed,
+  Volume, Base
+- **Fixed: a Special left its routine armed.** After playing a skill pack,
+  picking a plain animation kept the pack's routine live, so Play re-fired its
+  VFX and sound over an unrelated clip. The routine is now armed only while the
+  pack's own clip is selected, and switching away takes it off the stage too
+
+### Base Anim — play an action over a resting pose
+- **Base (None / Idle / Battle)** plays a resting clip underneath and lays your
+  selection over it as a montage: blend in, play through, blend back, rest
+  again. A loop reads as "rest, do the thing, rest" rather than a clip cutting
+  to itself
+- Built on the existing schedule machinery rather than a second system — a
+  schedule clip is already "segments over a base clip blending back out", so the
+  only missing piece was `transIn` in `pose.js`, the mirror of the existing
+  `transOut`. Measured on `at0` over `idl` with 6-frame blends, the pose is exact
+  on the base at both ends
+- A schedule keeps its own command sequencing; only the command that finishes
+  last hands back to the base, so a routine reads as one action instead of
+  sagging between commands
+- **None is the default**, so existing behaviour is unchanged unless you ask for
+  a base
+
+### The floor stays put, and so does the camera
+Two long-standing complaints, both mis-attributed to the camera at first —
+per-frame traces showed `camera.eye` byte-identical across every gesture, so the
+search moved elsewhere.
+
+- **The floor is fixed at Y = 0.** It used to be placed at the model's feet and
+  re-placed whenever the pose changed; frame-0 sole height varies by up to 0.14
+  between clips on one model (`bf0` −0.135 vs `idl` 0.009), so it jumped on
+  every pick and could rise past a low camera — which reads as the camera
+  dropping through the floor. A floor is scenery now, and nothing moves it
+- **Selecting another actor no longer re-frames the camera**, throwing away the
+  shot you just composed. Settings → **Reframe camera on Actor Selection**, off
+  by default. The first actor of a session is still framed, since there is no
+  view to preserve then
+- **Off a zone, the wheel zooms on the orbit centre** rather than the cursor. A
+  zone is a place you navigate; everything else is one subject already centred,
+  and cursor-anchored zoom drags it off centre
+
+### Camera Sequencer
+- **Lock to Actor now aims at bone0002 (the pelvis)** — the actor's centre of
+  mass — so a leap or a step stays framed. The rest-pose bounds centre would let
+  them walk out of shot; it stays as the fallback for anything without a
+  skeleton, such as a bare effect
+- **Scrubbing and stopping hand the camera back in the mode you drive in** —
+  fly with WASD on, orbit otherwise. Only playback needs fly mode, and being
+  stranded in it meant the next drag behaved as the sequence left it rather than
+  as you set it
+
+### Scene, settings and dropdowns
+- **Settings → Day Length** — real seconds per in-game day for the day/night
+  cycle, default 60. Junk input saves as the default rather than blocking. The
+  button's tooltip is now "Auto Play Day/Night cycle"
+- **Weather and time controls no longer require a 0x2F sky dome** — any zone
+  that declares weather gets them
+- **Navmesh loads from Settings → Navmesh Folder** before falling back to the
+  bundled copy
+- **Combo dropdowns cap at 340px again.** Headless UI's anchor writes an inline
+  `max-height` of the whole viewport, the same override the `max-width` rule
+  already worked around. Group headers are no longer sticky either — pinned at
+  the top, one blocked the panel's highlight gradient and drew as a flat band,
+  so the same header read as two different styles
+- **Details panel texture list restyled** as rows
+- **New background images** — Clouds and Rhapsody, plus the `Basic*` renames.
+  Picked up by the glob in `bgs.js`, so adding one needs no code change
+- Field of view moved above the divider in the Graphics popover
+
+### Code review pass — paths, platforms, races and cleanup
+**No machine-specific paths left in the tree:**
+- Dropped the hardcoded `D:\xidata` AltanaListener vgmstream fallback. vgmstream
+  is already embedded via `include_bytes!` and extracted to the user cache, so
+  the chain is env → co-located → embedded → PATH → None
+- The `xi` CLI shim resolves from `USERPROFILE`/`HOME` instead of a literal
+  `C:\Users\Josh\.local\bin\xi.exe`, matching `find_xi` on the Rust side
+- `bake-*.mjs` now require `--src` rather than defaulting to a personal path
+
+**Correctness:**
+- **`open_url` was Windows-only** despite shipping macOS and Linux bundles; it
+  now has the same `#[cfg]` branches `reveal_path` already had
+- **A zero-length clip froze the model.** `animFrame %= 0` is NaN, which then
+  fed `evaluate()` every frame. `setAnimation` and `seekTo` already guarded
+  against it; the render loop did not
+- **Concurrent sound decodes clobbered each other.** `decode_vgmstream` named its
+  temp file per process, not per call — and Tauri runs sync commands on a thread
+  pool, so a zone load decoding several sounds at once collided. Same fix in
+  `serve.py`
+- **Bumping `VGM_VERSION` now forces a re-extract.** The per-file skip was keyed
+  on byte length alone, so a same-size replacement was never rewritten
+- **Settings save is one `try` block.** Seventeen bare `setItem` calls meant a
+  quota error could persist `gamePath` but not `xiPath`, tearing settings in half
+- **`XI_DATA_DIR` meant two different things** — `main.rs` appended
+  `XiModelViewer`, `tools.rs` used it bare, so setting it split `notes.json` from
+  the xi-tools install. `tools.rs` now matches `main.rs`
+
+**Renderer:**
+- **Added `Renderer.dispose()`.** Nothing freed the GL objects on teardown, so
+  every HMR cycle leaked buffers, VAOs, textures and FBOs. It deliberately does
+  not call `loseContext()`: the canvas outlives the renderer and a lost context
+  stays lost, which would break the next mount
+- **Cached the normalised source path per batch.** `_sourceIn` ran
+  `toLowerCase` + `replace` + a regex for every batch in every draw pass whenever
+  a filter was set
+- **Collapsed `setMeshSourceFilter` and `setHiddenSources`**, which were
+  identical, so filter keys and batch keys cannot drift apart
+
+**Dedup and dead code:**
+- One `github.rs` for the release-fetch algorithm that had three copies, two of
+  them in this crate under different constant names — with offline tests
+- Extracted the diverged `:ensure_rc` from `Start.bat`/`Build.bat` into
+  `scripts/ensure_rc.bat`
+- Deleted `buildSolidGizmoMesh`, `projectRayOnAxis`, `unclaimedTextures`, a stray
+  `console.log` and a dead double-allocation in the skeleton overlay
+
+**`dev/` removed, dev server tightened:**
+- `xi mv update` in xi-tools replaces every baker, so the bake scripts and their
+  JSON are gone. `serve.py` moves to `scripts/` (it is the browser `/fs` backend,
+  which `xi mv update` does not replace), and browser-dev user data moves to
+  `.user-data` at the repo root
+- `_resolve` had a sandbox check whose branches both returned the same value,
+  reading as a guarantee it never gave. Removed, with a docstring saying the
+  `127.0.0.1` bind is the only bound
+- `/fs/list` and `/fs/read` now 404 rather than 500 on a missing file
+- Default dev-server port is 8766, matching what `vite.config.js` proxies to
+
+**Also:** granted `core:event:allow-listen` so the xi-log and tools-progress
+listeners work; the boot update check is skipped on dev builds, which always
+report the committed 1.0.1 and so nagged on every run; dropped the inert
+`PlacementPanel` memo deps and their `void` statements; documented `XI_DATA_DIR`
+and `XI_TOOLS_DIR`.
+
+---
+
+## [1.0.12] — 2026-08-31
+
+[Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.10...v1.0.12)
+
+### NPC effects
+- **Assets → NPCs gets the Both / Mesh / VFX control and the effect volume
+  slider.** An NPC keeps its routines inside the model DAT itself, so the actor's
+  own path is the effect source
+- **Nothing plays until you pick a routine.** An NPC has no `main`: its routines
+  are event-keyed (`dead`, `atk0`, `gurd`, `cast`, `damg`, …) and the server
+  fires them, with nothing in the DAT linking `ded0` to `dead`. The old "main,
+  else first playable" fallback picked an arbitrary routine and replayed it on
+  every clip — one effect for every animation, on every NPC. Routines are now
+  listed in an **Effect** dropdown instead
+
+### Skill packs
+- **`npcs.json` entries carry `anims: [{path, clips}]`** — the animation packs a
+  trust borrows. Each pack is self-contained: one clip plus its whole VFX bundle
+  under a `main` routine, the same shape as a PC action DAT
+- **A new Skill dropdown loads one pack at a time**, selects its clip and arms
+  its routine. One at a time because a set reuses clip ids, and merging would
+  shadow the duplicates
+
+Two fixes fell out of getting that on screen:
+- **`attachEffectSystem` deleted the incumbent GL texture on a name clash.**
+  Harmless for a PC (separate effect DAT, no overlap), fatal for an NPC whose
+  effect DAT *is* the model DAT — every body texture collided with itself and was
+  re-decoded through the particle path, repainting the model. It now leaves alone
+  the names the geometry actually draws with
+- **The floor was grounded on the bind pose**, whose straight legs hang below
+  every animated one — measured 0.0704 under Iroha's idle soles, which reads as
+  hovering. It re-grounds on frame 0 of each clip, and `fitCamera` no longer
+  undoes that. Framing still uses rest bounds; a pivot that moves with the
+  animation makes the model swim
+
+### Camera Sequencer
+- **Lock to Actor** — keyframes record facing the actor, and playback re-solves
+  the rotation every frame rather than interpolating it. Interpolated yaw/pitch
+  cut the corner where the path swings around
+- **Play always runs from the top**, cutting and rewinding the actor clip the way
+  Stop does. It used to resume from the playhead while the actor restarted at 0,
+  so a take begun anywhere but the start ran short against a full-length action
+- **Effects and sound now play.** The paired routine is re-triggered from the
+  clip's loop point, and a sequence runs the clip once with looping off — a shot
+  used to play mesh-only
+- **Scrubbing hands back an orbit camera** at the same eye and look direction.
+  Only playback needs fly mode; leaving it on meant the next drag flew away from
+  the shot
+- **Reaching the end rewinds to frame 0**, so the viewport and the timeline agree
+  on where the next take begins
+- **The working document survives closing the panel** — keyframes, length, fps
+  and toggles. Named sequences stay a separate explicit save
+- **Play at the end of a non-looping clip rewinds first.** It used to advance
+  straight past the end and stop on the same frame, which read as a dead button
+
+### Animation fixes
+- **PC battle and weapon-skill packs load properly** — battle skirt (`btl2`)
+  packs load per weapon type, cross-directory `Motion.csv` ranges expand so WS
+  clips get their waist/upper motion DATs, partial clips underlay idle, and
+  stance anims stay visible
+- **No invented blend-out when a schedule segment sets `transOut` 0.** Eagle Eye
+  Shot jittered on the `yu0` → `yu1` hand-off, reading as a single frame of
+  battle stance mid-weapon-skill: the routine leaves a real gap (yu0 ends at 58,
+  yu1 starts at 60) and both carry `transOut` 0, so the substituted 8-frame
+  default had the pose a quarter of the way back to base before the successor
+  claimed the joints. `transOut` 0 means "hand straight over", so the final pose
+  is held instead. Measured across all 21 PC schedules, only `main` changes — its
+  worst per-frame jump drops from 7.965 to 4.974
+- **The ranged weapon is stowed unless the action uses it.** A bow hung in view
+  through every melee swing: ranged weapons have no grip joint to re-parent
+  (`standardJointIndex` 255), so the mesh sat wherever its back-mount bone put
+  it. The game scales the weapon to 0 until it is drawn; the viewer now has a
+  renderer deny-list that does the same, and re-parents the bow onto the bow hand
+  (`gear_sets.json` `handRef`) for actions that use it
+
+### Scene → Flat Floor
+- **A plain untextured ground plane with a colour picker**, held separately from
+  a loaded floor so ticking it discards nothing. It reuses the existing plane
+  with a 1×1 solid texture, keeping the fade ring, the fog and the model's shadow
+
+### DAT Browser, gear lists and viewers
+- **Fixed a wedged file-index search.** DAT Browser search could stick on
+  "Building file index…" forever. Three things lined up: `loadMergedTables`
+  cached an all-empty result (its per-ROM catch is for uninstalled expansions,
+  but it also swallowed "no game path yet"), `ensureFilePathIndex` guarded with
+  `if (fileIndexRef.current)` and an empty array is truthy, and `FileTree`
+  rendered an empty index and a missing one identically. The Files view is the
+  default on a fresh profile, so the index effect ran before settings landed and
+  poisoned both caches. Now an empty table read throws instead of caching, the
+  guard tests `?.length` and clears the ref on failure, and a failed index says so
+- **Gear sections come from `characters.json` `gearSections`** rather than a
+  hard-coded array, so a new set in the generator needs no change here. Adds
+  Abjuration and the Mythic/Aeonic/Prime weapon sets, and merges Ebur, Furia and
+  Ebon into one section
+- **Weapon-slot leftovers fold into one "Other" bucket** pinned to the bottom —
+  Unidentified, the missing-DAT one-off and everything ungrouped. "None" is
+  exempt and still pins to the top
+- **DAT Browser badges images by group** — UI, Cutscene, Map — instead of calling
+  every image a Map
+- **Data Struct: SkeletonAnimation and Info rows are inspectable**
+- **Texture and image viewers get a persisted background colour** (right-click
+  clears back to the checker) plus zoom and pan
+- **Ctrl+LMB pans** the viewport
+- Gear lists resynced from xi-tools (the Limbus set was retired upstream)
+- AGENTS.md documents how to run the app outside Tauri and debug it
+
+---
+
+## [1.0.10] — 2026-08-30
+
+[Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.9...v1.0.10)
+
+### Zone geometry and culling
+- **PVS region culling** — parses 0x1C `drawDist` / `subAreaId` / `regionPtr` and
+  builds region sets with a camera-based region pick, under **View → Region
+  Culling**
+- **Collision proxies (drawDist 1.0) are hidden**, as are far-copy `m_`/`lnd_`
+  stand-ins when a richer twin is placed — this is the Ru'Aun z-fighting fix.
+  Sub-area sets draw under PVS
+- **Live Selection can pick sub-area, unplaced and collision objects** when they
+  are visible
+- **Section-fourcc mesh aliases are deferred** so they cannot steal real names —
+  this fixes Dynamis `saku` and `stardust`→`star`, plus roughly 69 similar zones
+- The ZoneDef modal shows the sub-area id
+
+### Objects panel
+- **Meshes / VFX / SFX tabs** in a segmented style, with SFX coming from live
+  `listSoundGroups` and offering play plus focus
+- **Kind sections** — Sky, Water, Collision, Sub areas, Unplaced — with kind
+  search, denser rows and an inset list shell
+- Close only; the minimize control and footer are gone
+
+### Effects and camera
+- **EffectActorsPanel** puts Character and NPC pickers under Effects, keeps the
+  loaded actor across views, and forces one F-style reset when leaving Zones for
+  Effects/PC/NPC
+- **Zone framing is FOV-aware**; entities and effects keep radius × 2.4, and **F
+  focuses the current selection**
+- **The camera F-resets on any Assets view switch**
+
+### Data Struct
+- **Click-through tables for EffectRoutine, SpriteSheetMesh, ParticleMesh,
+  ParticleKeyFrameData and WeightedMesh**, with atlas textures paired beside
+  sheets and meshes
+
+### Settings, tools and updates
+- **Settings split into General and XI Tools tabs**, with `tools_status` reading
+  disk only and `tools_check_updates` doing the network call
+- **GitHub API plus HTML fallback** for release lookups, and clearer rate-limit
+  errors
+- **The app update check runs through Tauri / `serve.py`**, avoiding a
+  browser→GitHub CORS failure
+- **Settings no longer resets mid-edit** — the draft is snapshotted only when the
+  modal opens, not on every FPS re-render. Grid and axes moved to the toolbar only
+
+### Lists and search
+- **Shared Search fields on the NPC, Music and Sound Effects lists**, and every
+  left-hand list search unified onto the same inset text field (search icons and
+  Options rules dropped)
+- **HD no longer breaks weapon-skill animations** — schedule and motion packs
+  load from game/pivot only, skipping HD stubs, and focus paths match via
+  ROM-relative keys
+- Effects Actors gear slots expanded, with a close/status toggle and an NPC inset
+  shell
+- Right-rail padding and gap polish, and shared UI chrome throughout
+
+---
+
+## [1.0.9] — 2026-08-29
+
+[Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.8...v1.0.9)
+
+### The app tells you when there's a new release
+- **A background release check on boot.** It asks GitHub for the newest published
+  release and, when it is newer than the running build, raises a dismissable
+  "Update available" notice with a link. Every failure path — offline,
+  rate-limited, timed out — resolves to nothing, so a failed check is invisible
+- **Nothing waits on it.** It runs from its own effect and is never awaited by
+  startup, and a zone-preview window skips the check entirely
+- **OK remembers the version**, so the notice stays gone until the next release
+  ships
+- **A green download CTA with the exe size**, and **File → Check for Updates**
+  with an up-to-date panel for checking on demand
+
+### Effects play on your character, with the cast animation
+- **Actor-bound generators attach to the character's skeleton.** 91% of
+  generators in retail effect DATs are SourceActor/TargetActor and the joint is
+  already in the data (`attachedJoint0`) — joint 0 is only 54% of them, so a
+  fixed root attach would misplace the rest onto hands, head and feet
+- **Particles no longer come out mirrored against the actor.** Joint transforms
+  are handed over pre-multiplied by `DISPLAY_ROT`, which cancels the one applied
+  on the way out — otherwise particles sat at the reflection of their joint with
+  smoke sinking instead of rising
+- **"Show Character Animation" plays the caster's motion.** The cast is not the
+  0x05 op — it is a call to a schedule on the character's own DAT (`shbk` black,
+  `shnj` ninjutsu, `shwh` white) which `flattenRoutine` was discarding as
+  unresolvable. Every race ships those `sh*` schedules empty while the `ca*` twin
+  carries the ref, so the twin is read instead
+- **The effect is delayed so generators fire on the release frame**, and the cast
+  is one clip with `segments`, so SkeletonPose cross-fades back to idle over 0.3s
+- **Effect attach slots (0/1/21/43/48…) map to actor height** rather than raw
+  bones, so Stone V stays on the floor and Fire/Thunder sit on the body
+- **A full transport — Play / Pause / Rewind / Loop.** The old single button was
+  labelled Stop but only ever set `effectPaused`; a non-looping routine now parks
+  instead of tearing itself down, so Rewind and Play can replay it
+- **Returning from Effects to NPC/PC keeps the loaded actor** and restores list
+  selection state
+- **A schedule segment no longer drops one step early.** The release check was
+  `< 1`, so the last 1/`transOut` of the travel happened in a single frame — this
+  affects schedule playback generally, not just casts
+
+### New particle types
+- **0x22 Distortion** — a billboard quad that refracts a frozen scene grab by
+  `hazeOffset`, for heat haze and Utsusemi shimmer
+- **0x24 Ring** — a procedural ring built from `ringMeshParams`
+- **The opaque-snap hack no longer applies to effect shells.** Alpha-blended
+  *zone* particle meshes do snap past the halfway point (confirmed on Bibiki
+  Bay's ocean), but forcing a = 1 on a spell shell made Utsusemi's cage read as
+  solid and over-bright, so the snap is gated on association kind
+
+### Viewport: backgrounds, floor and light
+- **Scene → Background Image**, backed by `ui/bgs/` and baked at build time. The
+  renderer draws it as a cover-fit full-screen quad after clear with depth off,
+  so models and floors sit on top; it is skipped when the skybox is on
+- **Backgrounds are cover-fit, not contain** — the clear colour used to show as
+  bars down the side of the canvas. Both scale factors stay ≤ 1 so the sampler
+  never reads outside [0,1]
+- **The floor fades out on a circle** instead of ending on a hard horizon.
+  Radial, not square, or the corners would reach further than the sides; the
+  fully-faded ring discards rather than writing depth
+- **Scene → Floor Repeat**, with the per-texture default and your multiplier kept
+  apart so picking a different floor re-derives the default without discarding
+  the setting
+- **Fixed a runaway canvas that read as being zoomed in.** `resize()` now
+  measures the window, not the canvas's own layout box — deriving the buffer from
+  `clientWidth` is self-referential, so buffer → layout → buffer grew every frame
+  until it pinned at 8192
+- **Entity shadows no longer clip on a hard diagonal.** Shadow maps are fitted to
+  the model's corners *plus* those corners dropped down the light onto the floor;
+  the old range came from model bounds alone, so past ~30° of sun elevation the
+  shadow's far end fell outside near/far
+- **A shadow light gizmo** (bottom-right, Shadows on only) overrides the
+  zone/entity sun direction for cast shadows; double-click resets and the
+  direction persists
+- **The light gizmo can reach the far hemisphere.** `hitDir` returned
+  `Math.sqrt(1 - d2)` for z, which is never negative, so dragging could only ever
+  aim the light in front of the model. A screen point maps to two directions, so
+  the second handle is the antipode, drawn mirrored through the centre;
+  right-dragging it negates the vector. The ray dashes when the light passes
+  behind
+- **Orbit after a pan pivots around the model** instead of snapping the view back
+- **The orbit pivot no longer overshoots small models.** Switching fly → orbit
+  dropped the pivot at least 5 units ahead of the camera, which suits a zone but
+  not an entity a couple of units across. The 5-unit floor is zones-only now
+
+### Data Struct and the DAT browser
+- **DAT Browser rows are labelled** — "Zone", "Gear", "Effect" — from data the
+  app already holds: the baked lists, the merged FTABLE map and the gear/zone-id
+  tables. A miss returns nothing rather than guessing
+- **`USER\<id>\` save files read properly.** They are not sectioned resource DATs
+  and previously fell through to the "not a sectioned DAT" card; `mcr.dat` /
+  `mcr<N>.dat` macro books and `mcr.ttl` / `mcr_2.ttl` book names now get real
+  layouts, everything else a hex/strings view
+- **A draggable table inspector** for SpellList (`mgc_`), AbilityList (`comm`)
+  and generic `mnc2`/`mon_`/`levc` tables
+- **XISTRING menu string tables** parse in the Data viewer with searchable
+  index/text rows — TOS and lobby help text, menu labels and so on
+- **XISTRING lengths and FA/ED control codes decode correctly** — u16 lengths
+  (the high word is flags), with runtime placeholders rendered as `{n}`/`{s}`/`{#}`
+  plus singular|plural forms and `{PS}`
+
+### Zone fidelity
+- **Fuzzy mesh resolve no longer latches onto fourcc aliases.** Mhaura's
+  `ship_room` is a sub-area placeholder with no mesh of its own, but the fuzzy
+  pass normalised it to "shiproom", matched that tail against the 4-char
+  section-id alias `room`, and drew `room-hanyou` — a generic house interior — on
+  the dock, where nothing renders in game. Fuzzy matching is now restricted to
+  real 0x2E mesh names. Across all 601 zone DATs this changes 306 of 1,106,615
+  placements: 296 phantom or duplicate draws dropped, and 10 `id_bus_path`
+  placements corrected from the fourcc `path` to the real mesh `bus_path`
+  *(reported by Crevox)*
+
+### UI plumbing
+- **The Graphics modal became a toolbar popover** — resolution scale, shadow
+  distance and FPS cap now use the same chrome as the FOV and Scene popovers, and
+  `GraphicsModal.jsx` is gone. One less full-screen modal for settings you tweak
+  while looking at the viewport
+- **A Scene popover** for background and floor, next to Graphics
+- **Native `title` tooltips moved onto Tippy** across 19 panels and modals,
+  keeping existing aria-labels for accessibility
+- **The settings modal was reworked**, and **Open notes file moved into Settings**
+- **Tippy raised above modals**, with tighter UiMenu/UiElementGroup notes wiring
+- **The tools bridge is exposed to the UI** — the `src-tauri` tools command
+  surface plus the `toolsBoot`/backend hooks the front end calls through
+- The last effect is restored on boot; empty-stage axes orientation fixed;
+  grid/axes preferences kept
+
+### Build and lists
+- **Background images ship once, not twice.** `ui/public/bgs/` held a
+  byte-identical second copy of every background — Vite bundled `ui/bgs/` through
+  the glob *and* copied `public/` verbatim, costing 2.6 MB of the build
+- **Baked entries carry only `path`.** Effect entries duplicated their DAT
+  location as `dir` + `file` alongside the full path; `EffectList` now derives the
+  `15/89` badge from the path, so search matches either form
+- **Placeholder duplicates dropped from the lists.** The upstream CSVs list some
+  DATs twice — once named, once blank — and the baker turned the blank row into a
+  "181/55" placeholder that read as a second effect sitting under the real one.
+  Two genuine names for one DAT (Corsair's 164/61 is both Dancer's Roll and
+  Double-Up) are left alone
+- Baked lists now emit 1-space indent to match each other, so a rebake is a small
+  diff rather than a 35k-line reformat
+- Dropped the dead `did_sync` flag in setup
+
+---
+
 ## [1.0.8] — 2026-08-27
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.5...v1.0.8)
 
 ### Open a zone straight from another tool
-- **`--zone` launch** — `xi-model-viewer.exe --zone "ROM/171/34.DAT"` starts the viewer already showing that zone, so a zone editor's Preview button, a shortcut or a shell can hand off to it
-- **Minimal by default** — viewport plus the Zone panel (weather, time of day, fog, brightness, background, BGM/ambient volume) and nothing else; **`--full-ui`** opens the same zone in the whole app
-- **`--weather`, `--time`, `--clock`** set the scene up front, and the window title becomes the zone name
-- **Takes the path you have** — game-relative, a leveleditor `game/ROM/…` path, the DAT's absolute path (game or HD root), or a zone id; unlisted prototype DATs still open by path
-- **A preview is a side trip** — it doesn't overwrite your last-opened DAT, doesn't change the page the full app restores to, and doesn't eat the first-launch About greeting. Launched before a game path was ever set, it asks for one and then opens your zone instead of the demo model
-- Browser dev mode takes the same options as a query string (`?zone=…&time=18:00`)
+- **`--zone` launch** — `xi-model-viewer.exe --zone "ROM/171/34.DAT"` starts the
+  viewer already showing that zone, so a zone editor's Preview button, a shortcut
+  or a shell can hand off to it
+- **Minimal by default** — viewport plus the Zone panel (weather, time of day,
+  fog, brightness, background, BGM/ambient volume) and nothing else; **`--full-ui`**
+  opens the same zone in the whole app
+- **`--weather`, `--time`, `--clock`** set the scene up front, and the window
+  title becomes the zone name
+- **Takes the path you have** — game-relative, a leveleditor `game/ROM/…` path,
+  the DAT's absolute path (game or HD root), or a zone id; unlisted prototype
+  DATs still open by path
+- **A preview is a side trip** — it doesn't overwrite your last-opened DAT,
+  doesn't change the page the full app restores to, and doesn't eat the
+  first-launch About greeting. Launched before a game path was ever set, it asks
+  for one and then opens your zone instead of the demo model
+- **One parser covers both shells** — a `launch_args` command hands the process
+  argv to the frontend, and browser dev mode takes the same options as a query
+  string (`?zone=…&time=18:00`)
 
 ### Title UI: inspect, edit, save
-- **UiMenu (0x30) windows** — frame and child buttons as a draggable table: position, size and Up/Down/Left/Right nav
-- **Edit and save back** — patch x/y/w/h and nav through `xi title menu` (xi-tools); the DAT reloads with edit mode intact so you can keep iterating
-- **Writes land in the right root** — pivot (Ashita / override), HD, or game, resolved per DAT
-- **UiElementGroup (0x31) inspector** — set header plus sprite layout rows (owner / parent / dest / src), same chrome as the menu window
-- **Console output panel** — bottom-left dump of what `xi` actually printed, optional auto-close with a countdown
+- **UiMenu (0x30) windows** — frame and child buttons as a draggable table:
+  position, size and Up/Down/Left/Right nav
+- **Edit and save back** — patch x/y/w/h and nav through `xi title menu`
+  (xi-tools); the DAT reloads with edit mode intact so you can keep iterating
+- **Writes land in the right root** — pivot (Ashita / override), HD, or game,
+  resolved per DAT
+- **UiElementGroup (0x31) inspector** — set header plus sprite layout rows
+  (owner / parent / dest / src), same chrome as the menu window
+- **Console output panel** — bottom-left dump of what `xi` actually printed,
+  optional auto-close with a countdown
 - **Settings** — xi-tools folder, setup helper, and toggles for the console panel
+- Backend `xi_run` / `xi_setup` helpers, and modal z-ordering so the new windows
+  stack sanely
 
 ### Notes on anything
-- **Free-text notes per DAT and per UiMenu**, stored in `%LOCALAPPDATA%\XiModelViewer\notes.json` — plain, portable, editable outside the app
-- **File tree tooltips show the note**, so a folder of numbered DATs stops being anonymous
-- Unsaved typing survives a DAT reload; optional close-on-save for the whole-DAT Notes window
+- **Free-text notes per DAT and per UiMenu**, stored in
+  `%LOCALAPPDATA%\XiModelViewer\notes.json` — plain, portable, editable outside
+  the app
+- **File tree tooltips show the note**, so a folder of numbered DATs stops being
+  anonymous
+- Unsaved typing survives a DAT reload; optional close-on-save for the whole-DAT
+  Notes window
 
 ### Images and sprites
-- **Title / lobby packs read properly** — `lobb` packs (a few 0x20 textures plus one giant 0x31 layout blob) used to show a single broken set and hide the local textures; those textures are now surfaced and the blob is parsed into sprite rows
-- **Sprite panel** under Images — every sprite in the layout, filtered to the atlas you have selected, searchable
+- **Title / lobby packs read properly** — `lobb` packs (a few 0x20 textures plus
+  one giant 0x31 layout blob) used to show a single broken set and hide the local
+  textures; those textures are now surfaced and the blob is parsed into sprite
+  rows
+- **Sprite panel** under Images — every sprite in the layout, filtered to the
+  atlas you have selected, searchable
 - Bare 0x20 textures no set claims (logos, `wardrb`) are listed instead of dropped
 
 ### Data Struct
-- **Bump maps (0x5D)** decode as height fields and preview as tangent-space normal maps
-- **Routes (0x06)** open as a keyframe table — camera paths from scene DATs, with focal length shown as FOV
-- **Companion tabs always there** — empty event / NPC / dialog DATs still get a tab, so the chrome stops collapsing as you switch
-- **Dialog by event or as flat lines**, with search across both; NPC rows show record and target index
+- **Bump maps (0x5D)** decode as height fields and preview as tangent-space
+  normal maps
+- **Routes (0x06)** open as a keyframe table — camera paths from scene DATs, with
+  focal length shown as FOV
+- **Companion tabs always there** — empty event / NPC / dialog DATs still get a
+  tab, so the chrome stops collapsing as you switch
+- **Dialog by event or as flat lines**, with search across both; NPC rows show
+  record and target index
 - Texture modals centre themselves
 
 ### Objects panel
-- **Meshes and Visual Effects tabs** — the VFX catalog lists zone-owned effects and the weather folder each one sits under
-- **Per-object and per-group visibility toggles**, with hidden and moved state marked on the row and reset on moved rows only
-- Sky and water listed only when Toggle Skybox is on; unplaced objects always listed
+- **Meshes and Visual Effects tabs** — the VFX catalog lists zone-owned effects
+  and the weather folder each one sits under, built from the full DAT tree rather
+  than only live generators
+- **Per-object and per-group visibility toggles**, with hidden and moved state
+  marked on the row and reset on moved rows only
+- Sky and water listed only when Toggle Skybox is on; unplaced objects always
+  listed; the chosen tab persists
 
 ### File browser
-- **Pin favourites** — pinned files sit in a folder at the top and open without yanking the tree back to their original path
+- **Pin favourites** — pinned files sit in a folder at the top and open without
+  yanking the tree back to their original path
 - Multiple top-level roots, each with its own label
 
 ### Zone list
-- **Dev / XI Modified group** — the 22 custom ROM10/100 dev zones (405–426), named by matching each zone's placement signature against the prototype sources rather than slot order, which is how 407 turned out to be Character Creation
-- **Sunny castle town and windmill town prototypes (403, 404)** added; stale 408/413 entries dropped
-- **Group ordering fixed** — curated groups were pinned to the bottom by a hardcoded list, so a new group fell through to the ROM-number comparator and sorted next to ROM (base). Anything matching `ROM<n>` now sorts by number and everything else tails alphabetically, so a future group needs no code change
+- **Dev / XI Modified group** — the 22 custom ROM10/100 dev zones (405–426),
+  named by matching each zone's placement signature against the prototype sources
+  rather than slot order, which is how 407 turned out to be Character Creation
+  from ROM/1/5 rather than a ROM/0/* prototype
+- **Sunny castle town and windmill town prototypes (403, 404)** added; stale
+  408/413 entries dropped
+- **Group ordering fixed** — curated groups were pinned to the bottom by a
+  hardcoded `TAIL_GROUPS` list, so a new group fell through to the ROM-number
+  comparator, where `+a.slice(3) || 1` gives NaN → 1 and it sorted next to ROM
+  (base). Anything matching `ROM<n>` now sorts by number and everything else tails
+  alphabetically, so a future group needs no code change
 
 ### Prototype zones and the Camera Sequencer
-- **Better prototype rendering** — prefer the richer of duplicate meshes, planar two-sided doors, particle-owned mills with spinning `w_mill` companions, an unplaced toggle, and sky / enclosing shells skipped when casting shadows
-- **Time track in the sequencer** — a 25px track with lerped time of day, a smooth time-only lighting path that doesn't rebuild the scene, and a rAF-driven day clock
+- **Better prototype rendering** — prefer the richer of duplicate meshes, planar
+  two-sided doors, particle-owned mills with spinning `w_mill` companions, an
+  unplaced toggle, and sky / enclosing shells skipped when casting shadows
+- **Time track in the sequencer** — a 25px track with lerped time of day, a
+  smooth time-only lighting path that doesn't rebuild the scene, and a rAF-driven
+  day clock
 
 ### Settings
 - **Game, HD and pivot paths** in one column
 - **Auto-switch to WASD on zone load** (fly camera: WASD / QE / Shift / wheel)
+
+---
 
 ## [1.0.5] — 2026-08-19
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.4...v1.0.5)
 
 ### Zones that actually work as a toolkit
-- **Data Struct knows the whole zone bundle** — mesh, events, dialog, NPCs as related DATs
-- **ZoneDef browser** — placements table you can open, search, and click through (including ParticleGenerators)
-- **In-modal particle preview** — play generators without hijacking the main viewport; resize, grid, background colour
-- **Live Selection** — click objects in the world, hover/select wireframes, drag a solid XYZ gizmo (in-memory moves, undo, reset on moved rows only)
-- **Converted / prototype zones** — smarter 0x54 vs 0x64 placement stride so patched DATs don't shred object lists; **A1R5G5B5** palette decode so prototype textures stop looking like green static
-- **Pin favourite zones** — hover → pin; pinned maps sit in a folder at the top of the list
+- **Data Struct knows the whole zone bundle** — mesh, events, dialog and NPCs as
+  related DATs, kept in sync as you change zone
+- **ZoneDef browser** — a placements table you can open, search and click through,
+  including ParticleGenerators
+- **In-modal particle preview** — play generators without hijacking the main
+  viewport; resize, grid and background colour
+- **Live Selection** — click objects in the world, hover/select wireframes, drag a
+  solid XYZ gizmo for in-memory moves, with undo and reset on moved rows only
+- **Converted / prototype zones** — a score-first 0x54 vs 0x64 placement stride so
+  patched DATs don't shred object lists
+- **A1R5G5B5 palette decode** so prototype textures stop looking like green
+  static. Paletted-texture headers carry bits-per-palette-entry in the final dword
+  of the 40-byte BITMAPINFOHEADER — 0x20 = 32-bit BGRA (1024 bytes), 0x10 =
+  16-bit A1R5G5B5 (512) — and both decoders read that field then discarded it and
+  hardcoded a 256 × u32 palette, which on a 0x10 texture scrambles the colours and
+  shifts every pixel by 512 bytes. That was the bright-green speckle covering Dev
+  Castle Town (`rom/0/33`). Retail content is always 0x20, so nothing else changes
+- **Pin favourite zones** — hover → pin; pinned maps sit in a folder at the top of
+  the list and persist in localStorage
+- **FPS limit options**
 
 ### Camera Sequencer
-- Two-track timeline (Camera + Scene), record at the playhead, scrub, multi-select + group drag
-- Snap, path **Curve**, Space play/pause, compact transport bar, zoom + wheel pan on the timeline
-- Fixed-height panel, width-only resize, **New** sequence; Tippy tooltips throughout
+- Two-track timeline (Camera + Scene), record at the playhead, scrub, multi-select
+  and group drag
+- Snap, path **Curve**, Space play/pause, a compact transport bar, zoom and wheel
+  pan on the timeline
+- Fixed-height panel, width-only resize, **New** sequence; Tippy tooltips
+  throughout
 
 ### Gear, files, and camera behaviour
-- **Gear + race skeleton** resolved from FTABLE / gear tables first (fewer wrong-race skins)
-- **Data Struct keeps every character slot** in the DAT dropdown when you inspect a piece
-- **File tree collapse sticks** — folders don't re-expand every frame
-- **Show in Explorer** fixed for paths with spaces (`Program Files (x86)`, etc.)
-- **Camera stays put** after you've orbit/pan/zoomed when loading the next entity DAT
+- **Gear + race skeleton resolved from FTABLE / gear tables first**, with the
+  binary name sniff demoted to a scored fallback — a digit-prefixed tag (`70hm`)
+  now beats a `_slot` suffix (`hm_m`), where before a bare `hf` substring in
+  random binary noise could pick the wrong skeleton and put male boots on a HumeF
+- **Data Struct keeps every character slot** in the DAT dropdown when you inspect
+  a piece
+- **File tree collapse sticks** — folders don't re-expand every frame. A folder you
+  closed stays closed, and reveal auto-expand only fires when the target *changes*
+  to something beneath it
+- **Show in Explorer fixed for paths with spaces** (`Program Files (x86)`, etc.).
+  Explorer's `/select` parsing splits a single `/select,C:\…` argument on spaces
+  and dumps you in Documents, so the flag and the path go in as two separate argv
+  entries, with the `\\?\` prefix from `canonicalize` stripped
+- **Camera stays put** after you've orbited, panned or zoomed when loading the
+  next entity DAT
 - Auto-play idle is **off by default** (still available in Settings)
 
 ### Quality of life
 - Tippy-only tooltips for UI hover text
 - Cleaner status/path flows around inspect ↔ 3D
 
+---
+
 ## [1.0.4] — 2026-08-18
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.3...v1.0.4)
 
-- **Multi-DAT Data Struct inspection** — dropdowns for characters and creation, RT/SHAPE/DMB/SQLE inspectors, structure search
+- **Multi-DAT Data Struct inspection** — dropdowns for characters and creation,
+  RT/SHAPE/DMB/SQLE inspectors, and structure search
 - **Gear** — auto skeleton pairing and per-slot mesh isolation
 - **Clickable texture and skeleton rows**, with a floating skeleton tree
-- **SoundEffectPointer playback** — play a row once with a spinning icon, click to stop
-- **Path links open in the OS file manager**, and path jumps land in the File Browser
-- Status bar split into left/right pills; orbit controls restored after toggling the creation cinematic camera
+- **SoundEffectPointer playback** — play a row once with a spinning icon, click to
+  stop
+- **Path links open in the OS file manager**, and path jumps land in the File
+  Browser
+- Status bar split into left/right pills; orbit controls restored after toggling
+  the creation cinematic camera
+
+---
 
 ## [1.0.3] — 2026-08-18
 
@@ -109,20 +658,31 @@ Releases and Windows builds: https://github.com/vekien/xi-model-viewer/releases
 
 - **Character creation faces** — expanded to 8, with A/B DMB variants
 - **Equipment mesh stays put** instead of dropping on reload
-- **SQLE animation playback** — PB sequences play as authored absolute poses, including floor staging
+- **SQLE animation playback** — PB sequences play as authored absolute poses,
+  including floor staging
 - **Prefix-channel locomotion** on equip bodies such as Mithra
 - Curated zone groups sort after ROM folders
+
+---
 
 ## [1.0.2] — 2026-08-13
 
 [Full changelog](https://github.com/vekien/xi-model-viewer/compare/v1.0.1...v1.0.2)
 
-- **Smart-open DATs by type** — zone, model, image, audio, effect, data — with path search and selection highlight in the File Browser
-- **Falls back to the structure inspector** with a clear notice when a file can't be drawn
-- **Pre-production MZB zones parse** — multi-group meshes, 0x54 placements, strips, blank names — so maps like ROM/0/41 and 46 load more completely
+- **Smart-open DATs by type** — zone, model, image, audio, effect, data — with
+  path search and selection highlight in the File Browser
+- **Falls back to the structure inspector** with a clear notice when a file can't
+  be drawn
+- **Pre-production MZB zones parse** — multi-group meshes, 0x54 placements,
+  strips, blank names — so maps like ROM/0/41 and 46 load more completely
 - Additional texture types decoded; structure Texture rows are clickable
-- Status-bar Data Struct toggle, and WASD stays on for zones opened from the browser
-- Build fix: `beforeBuildCommand` no longer looks for `ui/ui`
+- Status-bar Data Struct toggle, and WASD stays on for zones opened from the
+  browser
+- Build fix: `beforeBuildCommand` no longer looks for `ui/ui` — it uses an
+  explicit cwd of `../ui` with `npm run build` instead of the dual `--prefix`
+  fallback that errored when Tauri already ran from the `ui` tree
+
+---
 
 ## [1.0.1] — 2026-08-06
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 A FFXI asset browser — **zones, NPCs & monsters, playable characters, spell
 effects, textures, music, sound effects and raw DAT data** — with a **WebGL2**
-viewport, wrapped in a **Tauri 2** shell (~7 MB standalone exe, no Electron). Skinning runs on the GPU: the vertex
-shader rotates pre-weighted joint-local positions by per-joint pose quaternions;
-the CPU only evaluates the skeleton pose (one quat/trans/scale triplet per joint
-per frame).
+viewport, wrapped in a **Tauri 2** shell (one standalone ~38 MB exe, no
+Electron — it embeds vgmstream, the baked asset lists and the viewport
+backgrounds). Skinning runs on the GPU: the vertex shader rotates pre-weighted
+joint-local positions by per-joint pose quaternions; the CPU only evaluates the
+skeleton pose (one quat/trans/scale triplet per joint per frame).
 
 ## Download
 
@@ -18,20 +19,36 @@ notice until the next release.
 ## Features
 
 - **Zones** — full zone geometry with day/night time-of-day and weather
-  (auroras, fog, rain, …), adjustable brightness and scene background, a
-  searchable object/placement browser, and zone BGM + ambient sound effects.
-- **NPCs & monsters** — a categorised tree of every entity model. Play any of
-  its animations or schedules, scrub the timeline frame-by-frame, set playback
-  speed (10–200 %), and inspect the bone hierarchy in a skeleton overlay.
+  (auroras, fog, rain, …), adjustable brightness and scene background, and zone
+  BGM + ambient sound effects. The object browser groups placements by kind
+  (sky, water, collision, sub-areas, unplaced) with per-object and per-group
+  visibility toggles, and lists the zone's visual effects and sound groups
+  alongside its meshes. **Live Selection** picks objects in the world and drags
+  them on an XYZ gizmo (in-memory, with undo), and **View → Region Culling**
+  draws only what the zone's own PVS regions say is visible.
+- **NPCs & monsters** — a categorised tree of every entity model. A single
+  **Motion** picker covers its animations, schedules and the skill packs a trust
+  borrows; scrub the timeline frame-by-frame, set playback speed (10–200 %),
+  play the entity's own VFX routines, and inspect the bone hierarchy in a
+  skeleton overlay. **Base** (Idle / Battle) lays the selected clip over a
+  resting pose as a montage — blend in, play through, blend back.
 - **Characters** — compose a PC from race, face, weapons and gear. Gear is
-  grouped by set (Artifact / Relic / Empyrean / Ebur / Furia / Ebon) and sorted
-  A–Z; equipped weapons play their weapon-skill animations; the 40-character
-  look string is generated and copyable.
-- **Effects** — search and play any standalone spell/ability VFX (magic, job
-  abilities, summons, weapon skills) on an empty stage, with schedule picker,
-  playback speed and the effect's own sound.
+  grouped by set (Artifact / Relic / Empyrean / Ebur · Furia · Ebon /
+  Abjuration / Mythic / Aeonic / Prime) and sorted A–Z; equipped weapons play
+  their weapon-skill animations and a ranged weapon stays stowed unless the
+  action draws it; the 40-character look string is generated and copyable.
+- **Effects** — search and play any spell/ability VFX (magic, job abilities,
+  summons, weapon skills) on an empty stage *or on a loaded character or NPC* —
+  attached to the joints the DAT names, with the caster's own cast animation, a
+  Play / Pause / Rewind / Loop transport, playback speed and the effect's sound.
+- **Camera Sequencer** — a two-track timeline (Camera + Scene): record keyframes
+  at the playhead, scrub, curve the path between them, and lerp time-of-day
+  across a shot. **Lock to Actor** keeps a moving subject framed by tracking the
+  pelvis, effects and sound play back with the take, and sequences can be named
+  and saved.
 - **Images** — browse every UI, map and cutscene texture DAT with a filter,
-  per-set list and zoom.
+  per-set list and zoom, plus a **sprite panel** that lists every sprite in a
+  title/lobby layout, filtered to the atlas you have selected.
 - **Music & Sound FX** — play any BGW/SPW track (vgmstream-decoded) with a live
   waveform visualiser, seek bar and loop info.
 - **Data** — a DAT inspector: walks any DAT's section tree (folders, resource
@@ -39,10 +56,25 @@ notice until the next release.
   dumping payloads; textures open in a viewer on click. FTABLE/VTABLE pairs
   render as a searchable file-id → DAT table whose rows jump straight to the
   named DAT's structure, with gear model ids browsable per race/slot and
-  monster/NPC model ids resolved from the same tables.
-- **Throughout** — type-to-filter dropdowns, arrow-key list navigation,
-  reveal-any-DAT in the system file manager, wireframe / unlit / collision /
-  navmesh / skybox overlays, and glTF/FBX model export (via the xi-tools CLI).
+  monster/NPC model ids resolved from the same tables. Bump maps preview as
+  normal maps, routes open as keyframe tables, XISTRING menu strings and `USER\`
+  macro books get real layouts, and spell/ability tables open in a draggable
+  inspector.
+- **Title UI editing** — inspect UiMenu (0x30) windows and UiElementGroup (0x31)
+  sets as tables, then patch position, size and nav and **save back to the DAT**
+  through the xi-tools CLI. Writes land in the right root (pivot / HD / game),
+  resolved per DAT.
+- **Notes** — free-text notes on any DAT, kept in a plain
+  `%LOCALAPPDATA%\XiModelViewer\notes.json` you can edit outside the app. The
+  file tree shows each note as a tooltip, so a folder of numbered DATs stops
+  being anonymous.
+- **Scene** — background images, a flat floor with a colour picker, floor repeat
+  and a radial edge fade, plus a trackball gizmo for aiming the sun that casts
+  the model's shadow.
+- **Throughout** — type-to-filter dropdowns, search on every asset list,
+  arrow-key list navigation, pinned favourite zones and files, reveal-any-DAT in
+  the system file manager, wireframe / unlit / collision / navmesh / skybox
+  overlays, and glTF/FBX model export (via the xi-tools CLI).
 
 ## Screenshots
 


### PR DESCRIPTION
The changelog had stopped at 1.0.8, and the entries that were there mostly named the area something touched rather than what changed. This rewrites it end to end — every released version from 1.0.1 through 1.1.0, with each line saying what actually changed and, where it's interesting, why.

I put it together by walking all 61 commits between the tags and reading the code behind the vague ones, since a few of the bigger features landed under messages like `wip:` and `mucho improvo!`. Two bits of history are misleading if you go by `git log` alone, so both were checked against the actual trees: `77de5cc` (tagged 1.0.9) is a squash of a branch that later got merged in again, so a chunk of what looks like 1.0.10 work had already shipped in 1.0.9 — and `a25f38a` repeats several 1.0.12 bullets word for word, so 1.1.0 only lists the parts that were genuinely new. 1.0.6, 1.0.7 and 1.0.11 were never tagged, and the header says so instead of leaving unexplained gaps. The 1.1.0 entry was written from `a8ca7cf`, which is what the tag ended up pointing at.

There's a second commit tidying up the README while I was in there — the Features list was still describing about the 1.0.4 app, so the Camera Sequencer, title UI editing, notes and the scene controls have been added, and the gear set list corrected. Worth noting the header claimed a ~7 MB exe and the 1.1.0 build is 38 MB, so that's fixed too.